### PR TITLE
Create dedicated About page and update homepage copy

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About EmNet Community Management Ltd</title>
+  <meta name="description" content="Learn how EmNet Community Management Ltd builds sustainable, high-trust online communities.">
+  <meta property="og:title" content="About EmNet Community Management Ltd">
+  <meta property="og:description" content="Learn how EmNet Community Management Ltd builds sustainable, high-trust online communities.">
+  <meta property="og:type" content="website">
+  <link rel="icon" href="assets/favicon.png">
+  <link rel="stylesheet" href="styles/main.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <img src="assets/logo.png" alt="EmNet logo" class="logo">
+      <nav class="nav">
+        <a href="index.html">Home</a>
+        <a href="about.html" aria-current="page">About</a>
+        <a href="index.html#services">Services</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container">
+        <img src="assets/logo.png" alt="EmNet logo" class="hero-logo">
+        <h1>About EmNet</h1>
+        <p>Building sustainable, high-trust communities for projects that value long-term impact.</p>
+        <a class="btn" href="index.html#contact">Contact us</a>
+      </div>
+    </section>
+
+    <section class="container section">
+      <h2>Operational community growth</h2>
+      <p>EmNet Community Management Limited specialises in building sustainable, high-trust communities for projects that want more than short-term hype.</p>
+      <p>It is easy to make numbers rise. Followers can be bought, giveaways can be run, and spikes can be manufactured. But real community is measured differently. It is measured by whether people feel welcome, whether their questions are answered, whether they return, and whether they contribute. A thousand inflated accounts will never equal a hundred active, genuine participants.</p>
+      <p>At EmNet we recognise that numbers are still important — but they only have value when they represent real people. Our role is to give authenticity to those numbers by ensuring growth is grounded in genuine engagement and meaningful interaction. When a community count rises under our management, it reflects actual presence, not empty hype.</p>
+      <p>Our approach is operational at its core. We provide:</p>
+      <ul>
+        <li>Moderation frameworks that keep spaces safe, structured, and resilient.</li>
+        <li>Custom automation tools that streamline routine tasks and reduce risk.</li>
+        <li>Analytics and reporting that highlight substance — retention, resolved issues, depth of engagement — rather than vanity metrics.</li>
+      </ul>
+      <p>This work is often invisible, but it is what sustains a community once the marketing cycle has passed. By focusing on operational discipline, cultural clarity, and the human side of interaction, EmNet ensures communities remain credible, valuable, and durable.</p>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <small>© <span id="y"></span> EmNet Community Management Ltd</small>
+    </div>
+  </footer>
+  <script>document.getElementById('y').textContent = new Date().getFullYear()</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <div class="container header-inner">
       <img src="assets/logo.png" alt="EmNet logo" class="logo">
       <nav class="nav">
-        <a href="#about">About</a>
+        <a href="about.html">About</a>
         <a href="#services">Services</a>
         <a href="#contact">Contact</a>
       </nav>
@@ -35,16 +35,8 @@
 
     <section id="about" class="container section">
       <h2>About</h2>
-      <p>EmNet Community Management Limited specialises in building sustainable, high-trust communities for projects that want more than short-term hype.</p>
-      <p>It is easy to make numbers rise. Followers can be bought, giveaways can be run, and spikes can be manufactured. But real community is measured differently. It is measured by whether people feel welcome, whether their questions are answered, whether they return, and whether they contribute. A thousand inflated accounts will never equal a hundred active, genuine participants.</p>
-      <p>At EmNet we recognise that numbers are still important — but they only have value when they represent real people. Our role is to give authenticity to those numbers by ensuring growth is grounded in genuine engagement and meaningful interaction. When a community count rises under our management, it reflects actual presence, not empty hype.</p>
-      <p>Our approach is operational at its core. We provide:</p>
-      <ul>
-        <li>Moderation frameworks that keep spaces safe, structured, and resilient.</li>
-        <li>Custom automation tools that streamline routine tasks and reduce risk.</li>
-        <li>Analytics and reporting that highlight substance — retention, resolved issues, depth of engagement — rather than vanity metrics.</li>
-      </ul>
-      <p>This work is often invisible, but it is what sustains a community once the marketing cycle has passed. By focusing on operational discipline, cultural clarity, and the human side of interaction, EmNet ensures communities remain credible, valuable, and durable.</p>
+      <p>EmNet manages the backbone of online communities. From scalable moderation to purpose-built tools and reporting. Growth that reflects reality.</p>
+      <a class="btn" href="about.html">Learn more</a>
     </section>
 
     <section id="services" class="container section">


### PR DESCRIPTION
## Summary
- add a standalone About page that keeps the full company overview and includes a contact button
- shorten the homepage About section to the new teaser copy and link to the new page
- update navigation to point to the About page for easy access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd8ab2b2288322bbd07f5cd87c5986