### PR TITLE
Add How we work page and refresh site CTA/footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,37 @@
 # EmNet static site (dark theme)
 
-Free, GitHub Pages–hosted static website with a black base, grey sections, and neon pink accents to match your EmNet logo.
+A lightweight, single-folder site for EmNet Community Management Limited. All pages share a dark palette with neon pink accents that match the EmNet logo.
 
+## Pages & assets
+- `index.html` – homepage with hero, services overview, and contact call-to-action.
+- `about.html` – background on EmNet's approach to operational community growth.
+- `how-we-work.html` – breakdown of the audit, implement, sustain process with a next-step CTA.
+- `styles/main.css` – shared styling for layout, typography, and components.
+- `assets/` – logos, favicons, and the `og-image.png` used for social cards.
 
-## Replace assets
-1. Put your logo file at `public/assets/logo.png` (PNG or SVG works).
-2. Update the favicon at `public/assets/favicon.png`.
+## Update copy or visuals
+1. Replace the logo at `assets/logo.png` (PNG or SVG).
+2. Update the favicon at `assets/favicon.png`.
+3. Swap the social preview image at `assets/og-image.png` if you have a different share card.
+4. Edit page copy directly in the relevant HTML file. Each page already includes SEO, Open Graph, and Twitter card metadata.
 
 ## Publish on GitHub Pages
-1. Create a public GitHub repo (e.g. `emnet-site`).
-2. Upload these files to the `main` branch.
-3. Settings → Pages → Build and deployment → Source → **GitHub Actions**. Accept the suggested workflow, then edit the `upload-pages-artifact` step so that `path: public`.
-4. Commit the workflow file. On the next push your site will appear at `https://<username>.github.io/emnet-site/`.
+1. Create a public GitHub repository (for example, `emnet-site`).
+2. Upload all files from this directory to the `main` branch.
+3. In the repository, go to **Settings → Pages → Build and deployment → Source** and choose **GitHub Actions**. Accept the suggested workflow.
+4. In the generated workflow file, set `upload-pages-artifact` → `path: .` so the action publishes the repository root.
+5. Commit the workflow file. The next push will deploy the site at `https://<username>.github.io/<repository>/`.
 
-## Custom domain
-1. Create a `CNAME` file in the repo root containing just your domain, e.g.:
+## Custom domain (optional)
+1. Add a `CNAME` file in the repo root containing your domain, for example:
    ```
    emnet.example
    ```
-2. In Squarespace DNS:
+2. In your DNS provider, create records:
    - `www` CNAME → `<username>.github.io.`
    - A records for `@` → `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153`
-3. Enable HTTPS in GitHub Pages once the certificate is ready.
+3. Once DNS has propagated, enable HTTPS in GitHub Pages settings.
 
 ## Notes
-- Edit copy in `public/index.html`. Styling is in `public/styles/main.css`.
-- Buttons and links use neon pink (#ff2ebd). Adjust if you prefer a different accent.
+- Buttons and links use neon pink (`#ff2ebd`). Adjust `styles/main.css` if you want a different accent colour.
+- All pages share a footer script that keeps the copyright year current.

--- a/about.html
+++ b/about.html
@@ -3,11 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>About EmNet Community Management Ltd</title>
-  <meta name="description" content="Learn how EmNet Community Management Ltd builds sustainable, high-trust online communities.">
-  <meta property="og:title" content="About EmNet Community Management Ltd">
-  <meta property="og:description" content="Learn how EmNet Community Management Ltd builds sustainable, high-trust online communities.">
+  <title>About EmNet | EmNet Community Management Limited.</title>
+  <meta name="description" content="Discover the team, philosophy, and operational principles behind EmNet Community Management Limited.">
+  <meta property="og:title" content="About EmNet | EmNet Community Management Limited.">
+  <meta property="og:description" content="Discover the team, philosophy, and operational principles behind EmNet Community Management Limited.">
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="EmNet Community Management Limited">
+  <meta property="og:image" content="assets/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="About EmNet | EmNet Community Management Limited.">
+  <meta name="twitter:description" content="Discover the team, philosophy, and operational principles behind EmNet Community Management Limited.">
+  <meta name="twitter:image" content="assets/og-image.png">
   <link rel="icon" href="assets/favicon.png">
   <link rel="stylesheet" href="styles/main.css">
 </head>
@@ -19,6 +25,7 @@
         <a href="index.html">Home</a>
         <a href="about.html" aria-current="page">About</a>
         <a href="index.html#services">Services</a>
+        <a href="how-we-work.html">How we work</a>
         <a href="index.html#contact">Contact</a>
       </nav>
     </div>
@@ -51,9 +58,17 @@
 
   <footer class="site-footer">
     <div class="container">
-      <small>© <span id="y"></span> EmNet Community Management Ltd</small>
+      <small>© <span class="js-current-year"></span> EmNet Community Management Limited</small>
+      <small>Company No. 13716390</small>
+      <small>Registrar of Companies for England and Wales</small>
+      <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
+      <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
     </div>
   </footer>
-  <script>document.getElementById('y').textContent = new Date().getFullYear()</script>
+  <script>
+    document.querySelectorAll('.js-current-year').forEach(function (el) {
+      el.textContent = new Date().getFullYear();
+    });
+  </script>
 </body>
 </html>

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>How we work | EmNet Community Management Limited.</title>
+  <meta name="description" content="See how EmNet Community Management Limited audits, implements, and sustains resilient Web3 communities.">
+  <meta property="og:title" content="How we work | EmNet Community Management Limited.">
+  <meta property="og:description" content="See how EmNet Community Management Limited audits, implements, and sustains resilient Web3 communities.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="EmNet Community Management Limited">
+  <meta property="og:image" content="assets/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="How we work | EmNet Community Management Limited.">
+  <meta name="twitter:description" content="See how EmNet Community Management Limited audits, implements, and sustains resilient Web3 communities.">
+  <meta name="twitter:image" content="assets/og-image.png">
+  <link rel="icon" href="assets/favicon.png">
+  <link rel="stylesheet" href="styles/main.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <img src="assets/logo.png" alt="EmNet logo" class="logo">
+      <nav class="nav">
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="index.html#services">Services</a>
+        <a href="how-we-work.html" aria-current="page">How we work</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container">
+        <img src="assets/logo.png" alt="EmNet logo" class="hero-logo">
+        <h1>How we work.</h1>
+        <p>A structured partnership that keeps your community operations accountable, measurable, and resilient.</p>
+      </div>
+    </section>
+
+    <section class="container section">
+      <h2>Audit</h2>
+      <p>We begin with a deep review of your channels, tooling, and workflows to surface the friction points holding back authentic engagement. Stakeholders receive a concise report outlining risks, gaps, and immediate wins.</p>
+    </section>
+
+    <section class="container section">
+      <h2>Implement</h2>
+      <p>Based on the audit, we design and deploy the processes, automation, and playbooks that stabilise your community experience. From moderation coverage to bot integrations, every change is executed with measurable targets.</p>
+    </section>
+
+    <section class="container section">
+      <h2>Sustain</h2>
+      <p>Operational success is monitored through ongoing analytics, reporting, and leadership touchpoints. We refine the systems as your needs evolve so the community continues to grow with credibility and trust.</p>
+    </section>
+
+    <section class="container section">
+      <h2>Next step</h2>
+      <p>Ready to strengthen your community operations? Reach out and we will map the next actionable step together.</p>
+      <div class="cta-actions">
+        <a class="btn" href="mailto:Emnet@emnetcm.com">Email EmNet</a>
+        <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <small>© <span class="js-current-year"></span> EmNet Community Management Limited</small>
+      <small>Company No. 13716390</small>
+      <small>Registrar of Companies for England and Wales</small>
+      <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
+      <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
+    </div>
+  </footer>
+  <script>
+    document.querySelectorAll('.js-current-year').forEach(function (el) {
+      el.textContent = new Date().getFullYear();
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,11 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>EmNet Community Management Ltd</title>
-  <meta name="description" content="Community management, custom Telegram bots, and analytics for Web3 ecosystems.">
-  <meta property="og:title" content="EmNet Community Management Ltd">
-  <meta property="og:description" content="Community management, custom Telegram bots, and analytics for Web3 ecosystems.">
+  <title>EmNet Community Management Limited | Community operations for Web3.</title>
+  <meta name="description" content="Community operations, automation, and analytics that keep Web3 ecosystems running smoothly.">
+  <meta property="og:title" content="EmNet Community Management Limited | Community operations for Web3.">
+  <meta property="og:description" content="Community operations, automation, and analytics that keep Web3 ecosystems running smoothly.">
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="EmNet Community Management Limited">
+  <meta property="og:image" content="assets/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="EmNet Community Management Limited | Community operations for Web3.">
+  <meta name="twitter:description" content="Community operations, automation, and analytics that keep Web3 ecosystems running smoothly.">
+  <meta name="twitter:image" content="assets/og-image.png">
   <link rel="icon" href="assets/favicon.png">
   <link rel="stylesheet" href="styles/main.css">
 </head>
@@ -16,8 +22,10 @@
     <div class="container header-inner">
       <img src="assets/logo.png" alt="EmNet logo" class="logo">
       <nav class="nav">
+        <a href="index.html" aria-current="page">Home</a>
         <a href="about.html">About</a>
         <a href="#services">Services</a>
+        <a href="how-we-work.html">How we work</a>
         <a href="#contact">Contact</a>
       </nav>
     </div>
@@ -49,17 +57,28 @@
     </section>
 
     <section id="contact" class="container section">
-      <h2>Contact</h2>
-      <p>Email: <a class="btn" href="mailto:emnet@emnetcm.com">emnet@emnetcm.com</a></p>
-      <p>Telegram: <a class="btn" href="https://t.me/MillieMe85" target="_blank" rel="noopener">t.me/EmnetCM</a></p>
+      <h2>Get in touch</h2>
+      <p>Tell us what is not working in your channels. We will suggest practical fixes.</p>
+      <div class="cta-actions">
+        <a class="btn" href="mailto:Emnet@emnetcm.com">Email EmNet</a>
+        <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a>
+      </div>
     </section>
   </main>
 
   <footer class="site-footer">
     <div class="container">
-      <small>© <span id="y"></span> EmNet Community Management Ltd</small>
+      <small>© <span class="js-current-year"></span> EmNet Community Management Limited</small>
+      <small>Company No. 13716390</small>
+      <small>Registrar of Companies for England and Wales</small>
+      <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
+      <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
     </div>
   </footer>
-  <script>document.getElementById('y').textContent = new Date().getFullYear()</script>
+  <script>
+    document.querySelectorAll('.js-current-year').forEach(function (el) {
+      el.textContent = new Date().getFullYear();
+    });
+  </script>
 </body>
 </html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -91,6 +91,13 @@ body {
   color: #000;
 }
 
+.cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 16px;
+}
+
 /* Sections */
 .section {
   padding: 56px 0;


### PR DESCRIPTION
## Summary
- add a dedicated how-we-work page that outlines the audit, implement, and sustain approach
- update navigation, SEO metadata, and footer content across existing pages, plus add a homepage CTA block
- document the new structure and assets in the README and add shared CTA button styling

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dd93d37c948322bb855cc5f0bff972