### PR TITLE
Style how we work sections with background imagery

### DIFF
--- a/how-we-work.html
+++ b/how-we-work.html
@@ -40,19 +40,25 @@
       </div>
     </section>
 
-    <section class="container section">
-      <h2>Audit</h2>
-      <p>We begin with a deep review of your channels, tooling, and workflows to surface the friction points holding back authentic engagement. Stakeholders receive a concise report outlining risks, gaps, and immediate wins.</p>
+    <section class="section workflow-section workflow-section--audit">
+      <div class="container workflow-content">
+        <h2>Audit</h2>
+        <p>We begin with a deep review of your channels, tooling, and workflows to surface the friction points holding back authentic engagement. Stakeholders receive a concise report outlining risks, gaps, and immediate wins.</p>
+      </div>
     </section>
 
-    <section class="container section">
-      <h2>Implement</h2>
-      <p>Based on the audit, we design and deploy the processes, automation, and playbooks that stabilise your community experience. From moderation coverage to bot integrations, every change is executed with measurable targets.</p>
+    <section class="section workflow-section workflow-section--implement">
+      <div class="container workflow-content">
+        <h2>Implement</h2>
+        <p>Based on the audit, we design and deploy the processes, automation, and playbooks that stabilise your community experience. From moderation coverage to bot integrations, every change is executed with measurable targets.</p>
+      </div>
     </section>
 
-    <section class="container section">
-      <h2>Sustain</h2>
-      <p>Operational success is monitored through ongoing analytics, reporting, and leadership touchpoints. We refine the systems as your needs evolve so the community continues to grow with credibility and trust.</p>
+    <section class="section workflow-section workflow-section--sustain">
+      <div class="container workflow-content">
+        <h2>Sustain</h2>
+        <p>Operational success is monitored through ongoing analytics, reporting, and leadership touchpoints. We refine the systems as your needs evolve so the community continues to grow with credibility and trust.</p>
+      </div>
     </section>
 
     <section class="container section">

--- a/styles/main.css
+++ b/styles/main.css
@@ -107,6 +107,59 @@ body {
   color: #ff2ebd; /* neon pink section headers */
 }
 
+.workflow-section {
+  --workflow-bg: none;
+  position: relative;
+  padding: 140px 0;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  color: #ffffff;
+  overflow: hidden;
+}
+
+.workflow-section::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: var(--workflow-bg) center / cover no-repeat;
+  z-index: 0;
+}
+
+.workflow-section::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.65) 0%, rgba(0, 0, 0, 0.75) 100%);
+  z-index: 0;
+}
+
+.workflow-section + .workflow-section {
+  margin-top: 0;
+}
+
+.workflow-content {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+}
+
+.workflow-content p {
+  color: #e2e2e2;
+}
+
+.workflow-section--audit {
+  --workflow-bg: url('../assets/audit.png');
+}
+
+.workflow-section--implement {
+  --workflow-bg: url('../assets/implement.png');
+}
+
+.workflow-section--sustain {
+  --workflow-bg: url('../assets/sustain.png');
+}
+
 .cards {
   list-style: none;
   padding: 0;
@@ -151,5 +204,9 @@ body {
 
   .hero h1 {
     font-size: 32px;
+  }
+
+  .workflow-section {
+    padding: 100px 0;
   }
 }


### PR DESCRIPTION
## Summary
- add full-width background imagery behind the audit, implement, and sustain sections on the How we work page
- introduce reusable workflow section styles with gradient overlays and responsive padding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd9f107bd083228c80ac4ddec94edd