### PR TITLE
Move workflow shortcuts navigation under hero

### DIFF
--- a/how-we-work.html
+++ b/how-we-work.html
@@ -37,27 +37,84 @@
         <img src="assets/logo.png" alt="EmNet logo" class="hero-logo">
         <h1>How we work.</h1>
         <p>A structured partnership that keeps your community operations accountable, measurable, and resilient.</p>
+        <nav class="workflow-shortcuts" aria-label="Workflow shortcuts">
+          <a href="#audit">Audit</a>
+          <span aria-hidden="true">&gt;</span>
+          <a href="#implement">Implement</a>
+          <span aria-hidden="true">&gt;</span>
+          <a href="#sustain">Sustain</a>
+        </nav>
       </div>
     </section>
 
-    <section class="section workflow-section workflow-section--audit">
+    <section class="section workflow-section workflow-section--audit" id="audit">
       <div class="container workflow-content">
         <h2>Audit</h2>
-        <p>We begin with a deep review of your channels, tooling, and workflows to surface the friction points holding back authentic engagement. Stakeholders receive a concise report outlining risks, gaps, and immediate wins.</p>
+        <p><strong>Purpose:</strong> Experience your community as a member would, then map the systems behind it.</p>
+        <h3>What we do</h3>
+        <ul>
+          <li>Join the group to get a first-hand user experience — onboarding, rules, flow of conversation.</li>
+          <li>Review all active bots, commands, and functions in place.</li>
+          <li>Check how data is being captured, if at all (logs, Sheets, reporting hooks).</li>
+          <li>Identify risks in the current bot stack — permissions, admin exposure, gaps in coverage.</li>
+          <li>Assess security weak points and common failure points.</li>
+          <li>Review any use of social growth platforms (airdrops, invite trackers) and educate owners on the risks they pose.</li>
+        </ul>
+        <h3>What you get</h3>
+        <ul>
+          <li>A concise audit report outlining current setup.</li>
+          <li>A list of existing tools and their functions.</li>
+          <li>Risks flagged with explanations in plain English.</li>
+          <li>Quick wins that can be implemented immediately with the current bot stack.</li>
+          <li>Education on the pitfalls of artificial growth platforms.</li>
+        </ul>
       </div>
     </section>
 
-    <section class="section workflow-section workflow-section--implement">
+    <section class="section workflow-section workflow-section--implement" id="implement">
       <div class="container workflow-content">
         <h2>Implement</h2>
-        <p>Based on the audit, we design and deploy the processes, automation, and playbooks that stabilise your community experience. From moderation coverage to bot integrations, every change is executed with measurable targets.</p>
+        <p><strong>Purpose:</strong> Deploy processes, automation, and playbooks that stabilise your community.</p>
+        <h3>What we do</h3>
+        <ul>
+          <li>Define clear roles, coverage schedules, and escalation paths.</li>
+          <li>Configure or build bots: onboarding, quizzes, XP systems, spam filters, and on-chain checks.</li>
+          <li>Establish baseline metrics: retention, response time, solved issues, contributor growth.</li>
+          <li>Pilot in a smaller group if needed, then roll out.</li>
+          <li>Train moderators on rules, tools, and incident handling.</li>
+          <li>Launch with clear communication to the community.</li>
+        </ul>
+        <h3>What you get</h3>
+        <ul>
+          <li>A working playbook and rota.</li>
+          <li>Configured bots with documentation.</li>
+          <li>Training materials and moderator runbooks.</li>
+          <li>Baseline data for future reports.</li>
+        </ul>
       </div>
     </section>
 
-    <section class="section workflow-section workflow-section--sustain">
+    <section class="section workflow-section workflow-section--sustain" id="sustain">
       <div class="container workflow-content">
         <h2>Sustain</h2>
-        <p>Operational success is monitored through ongoing analytics, reporting, and leadership touchpoints. We refine the systems as your needs evolve so the community continues to grow with credibility and trust.</p>
+        <p><strong>Purpose:</strong> Keep systems running smoothly and evolving with the community.</p>
+        <h3>What we do</h3>
+        <ul>
+          <li>Monitor channels and dashboards for risks and anomalies.</li>
+          <li>Tune bot thresholds and rules as behaviour changes.</li>
+          <li>Provide monthly reports with retention, solved issues, and engagement depth.</li>
+          <li>Hold review sessions to agree changes and priorities.</li>
+          <li>Run incident reviews and update playbooks after events.</li>
+          <li>Introduce sustainable gamified features — e.g. a custom quiz function tailored to your company, automated for ongoing engagement.</li>
+          <li>Suggest improvements to keep features fresh while avoiding hollow “growth hacks.”</li>
+        </ul>
+        <h3>What you get</h3>
+        <ul>
+          <li>Ongoing stability and reduced incidents.</li>
+          <li>Monthly reporting that separates signal from noise.</li>
+          <li>Automated gamified features that engage without draining resources.</li>
+          <li>A living system that adapts as your project and community grow.</li>
+        </ul>
       </div>
     </section>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -148,6 +148,29 @@ body {
   color: #e2e2e2;
 }
 
+.workflow-shortcuts {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 16px 0;
+  font-weight: 600;
+  color: #bbbbbb;
+}
+
+.workflow-shortcuts a {
+  color: #ff2ebd;
+  text-decoration: none;
+}
+
+.workflow-shortcuts a:hover,
+.workflow-shortcuts a:focus-visible {
+  text-decoration: underline;
+}
+
+.workflow-shortcuts span {
+  color: #666666;
+}
+
 .workflow-section--audit {
   --workflow-bg: url('../assets/audit.png');
 }


### PR DESCRIPTION
## Summary
- relocate the Audit > Implement > Sustain shortcut bar to sit beneath the hero copy
- remove duplicate shortcut navs from each workflow section so only one bar remains

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dda3bb52e88322bfdbe84e41e41f9d