### PR TITLE
Tweak hero spacing and workflow navigation layout

### DIFF
--- a/how-we-work.html
+++ b/how-we-work.html
@@ -35,8 +35,21 @@
     <section class="hero">
       <div class="container">
         <img src="assets/logo.png" alt="EmNet logo" class="hero-logo">
-        <h1>How we work.</h1>
-        <p>A structured partnership that keeps your community operations accountable, measurable, and resilient.</p>
+        <h1>How we work</h1>
+        <p class="hero-strapline">A structured partnership that keeps your community operations accountable, measurable, and resilient.</p>
+        <div class="hero-intro">
+          <p>EmNet offers two ways of working with us:</p>
+          <ul>
+            <li><strong>Individual services</strong> — choose only what you need, such as an audit, a bot build, or reporting.</li>
+            <li><strong>AIS package</strong> — our full Audit, Implement, Sustain framework delivered end-to-end.</li>
+          </ul>
+          <p>Either path gives you practical operations that are accountable, measurable, and resilient.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section workflow-section workflow-section--audit" id="audit">
+      <div class="container workflow-content">
         <nav class="workflow-shortcuts" aria-label="Workflow shortcuts">
           <a href="#audit">Audit</a>
           <span aria-hidden="true">&gt;</span>
@@ -44,11 +57,6 @@
           <span aria-hidden="true">&gt;</span>
           <a href="#sustain">Sustain</a>
         </nav>
-      </div>
-    </section>
-
-    <section class="section workflow-section workflow-section--audit" id="audit">
-      <div class="container workflow-content">
         <h2>Audit</h2>
         <p><strong>Purpose:</strong> Experience your community as a member would, then map the systems behind it.</p>
         <h3>What we do</h3>
@@ -116,6 +124,16 @@
           <li>A living system that adapts as your project and community grow.</li>
         </ul>
       </div>
+    </section>
+
+    <section class="container section">
+      <h2>Additional services</h2>
+      <p>Alongside AIS and individual stages, EmNet also offers:</p>
+      <ul>
+        <li><strong>Custom bot builds</strong> — developed to order for your specific needs.</li>
+        <li><strong>Bluesky analytics reports</strong> — provide a username and timeframe for a quick, clear engagement report.</li>
+        <li><strong>Standard moderation</strong> — professional coverage at a reasonable rate.</li>
+      </ul>
     </section>
 
     <section class="container section">

--- a/styles/main.css
+++ b/styles/main.css
@@ -76,6 +76,26 @@ body {
   color: #bbbbbb;
 }
 
+.hero-strapline {
+  margin-bottom: 40px;
+}
+
+.hero-intro p:last-of-type {
+  margin-bottom: 0;
+}
+
+.hero ul {
+  display: inline-block;
+  margin: 0 auto 20px;
+  padding-left: 20px;
+  text-align: left;
+  color: #bbbbbb;
+}
+
+.hero ul li {
+  margin-bottom: 8px;
+}
+
 .btn {
   display: inline-block;
   padding: 10px 16px;
@@ -149,12 +169,14 @@ body {
 }
 
 .workflow-shortcuts {
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
-  margin: 16px 0;
+  margin: 32px auto;
   font-weight: 600;
   color: #bbbbbb;
+  width: fit-content;
 }
 
 .workflow-shortcuts a {


### PR DESCRIPTION
## Summary
- wrap the hero intro copy so the strapline can keep extra breathing room above the service descriptions
- adjust the workflow shortcuts styling to center the bar and double the space before the Audit heading

## Testing
- Not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68ddab7c233c832288802c285c090b15