### PR TITLE
Add divider imagery between key sections

### DIFF
--- a/about.html
+++ b/about.html
@@ -41,6 +41,8 @@
       </div>
     </section>
 
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+
     <section class="container section">
       <h2>Operational community growth</h2>
       <p>EmNet Community Management Limited specialises in building sustainable, high-trust communities for projects that want more than short-term hype.</p>

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -48,6 +48,8 @@
       </div>
     </section>
 
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+
     <section class="section workflow-section workflow-section--audit" id="audit">
       <div class="container workflow-content">
         <nav class="workflow-shortcuts" aria-label="Workflow shortcuts">
@@ -79,6 +81,8 @@
       </div>
     </section>
 
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+
     <section class="section workflow-section workflow-section--implement" id="implement">
       <div class="container workflow-content">
         <h2>Implement</h2>
@@ -101,6 +105,8 @@
         </ul>
       </div>
     </section>
+
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
 
     <section class="section workflow-section workflow-section--sustain" id="sustain">
       <div class="container workflow-content">
@@ -126,6 +132,8 @@
       </div>
     </section>
 
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+
     <section class="container section">
       <h2>Additional services</h2>
       <p>Alongside AIS and individual stages, EmNet also offers:</p>
@@ -135,6 +143,8 @@
         <li><strong>Standard moderation</strong> — professional coverage at a reasonable rate.</li>
       </ul>
     </section>
+
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
 
     <section class="container section">
       <h2>Next step</h2>

--- a/index.html
+++ b/index.html
@@ -41,11 +41,15 @@
       </div>
     </section>
 
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+
     <section id="about" class="container section">
       <h2>About</h2>
       <p>EmNet manages the backbone of online communities. From scalable moderation to purpose-built tools and reporting. Growth that reflects reality.</p>
       <a class="btn" href="about.html">Learn more</a>
     </section>
+
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
 
     <section id="services" class="container section">
       <h2>Services</h2>
@@ -55,6 +59,8 @@
         <li class="card"><h3>Analytics</h3><p>Community reporting, KPI dashboards, automated exports.</p></li>
       </ul>
     </section>
+
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
 
     <section id="contact" class="container section">
       <h2>Get in touch</h2>

--- a/styles/main.css
+++ b/styles/main.css
@@ -118,6 +118,14 @@ body {
   margin-top: 16px;
 }
 
+.section-divider {
+  display: block;
+  width: 200px;
+  max-width: 60%;
+  margin: 32px auto;
+  height: auto;
+}
+
 /* Sections */
 .section {
   padding: 56px 0;


### PR DESCRIPTION
## Summary
- add decorative divider image elements between major sections on each public page
- style the divider to display consistently across layouts

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ddb02114e88322bb983cdd3b75f84d