### PR TITLE
Reorder home page sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,16 +41,6 @@
       </div>
     </section>
 
-    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
-
-    <section id="about" class="container section">
-      <h2>About</h2>
-      <p>EmNet manages the backbone of online communities. From scalable moderation to purpose-built tools and reporting. Growth that reflects reality.</p>
-      <a class="btn" href="about.html">Learn more</a>
-    </section>
-
-    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
-
     <section id="services" class="container section">
       <h2>Services</h2>
       <ul class="cards">
@@ -60,7 +50,11 @@
       </ul>
     </section>
 
-    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+    <section id="about" class="container section">
+      <h2>About</h2>
+      <p>EmNet manages the backbone of online communities. From scalable moderation to purpose-built tools and reporting. Growth that reflects reality.</p>
+      <a class="btn" href="about.html">Learn more</a>
+    </section>
 
     <section id="contact" class="container section">
       <h2>Get in touch</h2>

--- a/styles/main.css
+++ b/styles/main.css
@@ -120,9 +120,8 @@ body {
 
 .section-divider {
   display: block;
-  width: 200px;
-  max-width: 60%;
-  margin: 32px auto;
+  width: min(100%, 320px);
+  margin: 16px auto;
   height: auto;
 }
 


### PR DESCRIPTION
## Summary
- move the home page About section to sit directly above the Get in touch section
- remove the divider image elements so the home page layout no longer includes the erroneous separators

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddb3561a0483228a198cdc2b50dbff