### PR TITLE
Reduce About page hero logo size

### DIFF
--- a/about.html
+++ b/about.html
@@ -17,7 +17,7 @@
   <link rel="icon" href="assets/favicon.png">
   <link rel="stylesheet" href="styles/main.css">
 </head>
-<body>
+<body class="about-page">
   <header class="site-header">
     <div class="container header-inner">
       <img src="assets/logo.png" alt="EmNet logo" class="logo">

--- a/styles/main.css
+++ b/styles/main.css
@@ -63,6 +63,10 @@ body {
   height: auto;
 }
 
+body.about-page .hero-logo {
+  width: min(130px, 35vw);
+}
+
 .hero h1 {
   font-size: 40px;
   margin: 0 0 10px;


### PR DESCRIPTION
## Summary
- add an about-page body class to target the About hero logo
- halve the About page hero logo width to reduce its size by 50%

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddb7e787608322ac689581271b4f8a