### PR TITLE
Add trust metrics and CTA updates

### DIFF
--- a/assets/site.js
+++ b/assets/site.js
@@ -1,0 +1,66 @@
+(function () {
+  if (!('IntersectionObserver' in window)) {
+    return;
+  }
+
+  const targets = Array.from(document.querySelectorAll('.metric-number, .ais-heading'));
+  if (!targets.length) {
+    return;
+  }
+
+  const motionPreference = window.matchMedia('(prefers-reduced-motion: reduce)');
+  let observer;
+
+  const disconnectObserver = () => {
+    if (!observer) {
+      return;
+    }
+    targets.forEach((el) => {
+      observer.unobserve(el);
+      el.classList.remove('is-active');
+    });
+    observer.disconnect();
+    observer = undefined;
+  };
+
+  const initObserver = () => {
+    observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-active');
+          } else {
+            entry.target.classList.remove('is-active');
+          }
+        });
+      },
+      {
+        root: null,
+        rootMargin: '-33% 0px -33% 0px',
+        threshold: 0,
+      }
+    );
+
+    targets.forEach((el) => observer.observe(el));
+  };
+
+  const handlePreferenceChange = (event) => {
+    if (event.matches) {
+      disconnectObserver();
+    } else {
+      initObserver();
+    }
+  };
+
+  if (motionPreference.matches) {
+    return;
+  }
+
+  initObserver();
+
+  if (typeof motionPreference.addEventListener === 'function') {
+    motionPreference.addEventListener('change', handlePreferenceChange);
+  } else if (typeof motionPreference.addListener === 'function') {
+    motionPreference.addListener(handlePreferenceChange);
+  }
+})();

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -26,7 +26,7 @@
         <a href="about.html">About</a>
         <a href="index.html#services">Services</a>
         <a href="how-we-work.html" aria-current="page">How we work</a>
-        <a href="index.html#contact">Contact</a>
+        <a href="#contact">Contact</a>
       </nav>
     </div>
   </header>
@@ -45,8 +45,14 @@
           </ul>
           <p>Either path gives you practical operations that are accountable, measurable, and resilient.</p>
         </div>
+        <div class="ais-bridge" id="ais">
+          <h2>AIS</h2>
+          <p>AIS is our full framework: Audit, Implement, Sustain. It starts with a hands-on review, then structured improvements and long-term stability.</p>
+        </div>
       </div>
     </section>
+
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
 
     <section class="section workflow-section workflow-section--audit" id="audit">
       <div class="container workflow-content">
@@ -57,7 +63,7 @@
           <span aria-hidden="true">&gt;</span>
           <a href="#sustain">Sustain</a>
         </nav>
-        <h2>Audit</h2>
+        <h2 class="ais-heading">Audit</h2>
         <p><strong>Purpose:</strong> Experience your community as a member would, then map the systems behind it.</p>
         <h3>What we do</h3>
         <ul>
@@ -83,7 +89,7 @@
 
     <section class="section workflow-section workflow-section--implement" id="implement">
       <div class="container workflow-content">
-        <h2>Implement</h2>
+        <h2 class="ais-heading">Implement</h2>
         <p><strong>Purpose:</strong> Deploy processes, automation, and playbooks that stabilise your community.</p>
         <h3>What we do</h3>
         <ul>
@@ -108,7 +114,7 @@
 
     <section class="section workflow-section workflow-section--sustain" id="sustain">
       <div class="container workflow-content">
-        <h2>Sustain</h2>
+        <h2 class="ais-heading">Sustain</h2>
         <p><strong>Purpose:</strong> Keep systems running smoothly and evolving with the community.</p>
         <h3>What we do</h3>
         <ul>
@@ -132,24 +138,23 @@
 
     <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
 
-    <section class="container section">
-      <h2>Additional services</h2>
-      <p>Alongside AIS and individual stages, EmNet also offers:</p>
+    <section class="container section individual-services">
+      <h2>Individual services</h2>
       <ul>
-        <li><strong>Custom bot builds</strong> — developed to order for your specific needs.</li>
-        <li><strong>Bluesky analytics reports</strong> — provide a username and timeframe for a quick, clear engagement report.</li>
-        <li><strong>Standard moderation</strong> — professional coverage at a reasonable rate.</li>
+        <li><strong>Custom bot builds</strong> — built to order for your needs</li>
+        <li><strong>Bluesky analytics reports</strong> — send a username and timeframe for a clear engagement report</li>
+        <li><strong>Standard moderation</strong> — reliable coverage at a reasonable rate</li>
       </ul>
     </section>
 
     <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
 
-    <section class="container section">
+    <section id="contact" class="container section final-cta">
       <h2>Next step</h2>
-      <p>Ready to strengthen your community operations? Reach out and we will map the next actionable step together.</p>
+      <p>Tell us what is not working in your channels. We will map the fastest fix.</p>
       <div class="cta-actions">
         <a class="btn" href="mailto:Emnet@emnetcm.com">Email EmNet</a>
-        <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a>
+        <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">Telegram: EmnetCm</a>
       </div>
     </section>
   </main>
@@ -163,6 +168,7 @@
       <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
     </div>
   </footer>
+  <script src="assets/site.js" defer></script>
   <script>
     document.querySelectorAll('.js-current-year').forEach(function (el) {
       el.textContent = new Date().getFullYear();

--- a/index.html
+++ b/index.html
@@ -50,18 +50,55 @@
       </ul>
     </section>
 
+    <section id="trust" class="section trust-strip">
+      <div class="container">
+        <h2>Trust metrics</h2>
+        <div class="trust-metrics" role="list">
+          <article class="trust-metric" role="listitem">
+            <p class="trust-metric-heading"><span class="metric-number">90%</span> spam reduction</p>
+            <p class="metric-detail">in a 30k-member group, four weeks after new bot configuration</p>
+          </article>
+          <article class="trust-metric" role="listitem">
+            <p class="trust-metric-heading"><span class="metric-number">3h → 20min</span> response time</p>
+            <p class="metric-detail">median time to first helpful reply</p>
+          </article>
+          <article class="trust-metric" role="listitem">
+            <p class="trust-metric-heading"><span class="metric-number">+42%</span> contributor growth</p>
+            <p class="metric-detail">month over month after playbook rollout</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+
+    <section id="cta-mid" class="section cta-mid">
+      <div class="container">
+        <h2>Keep your community on track</h2>
+        <p>Let&rsquo;s review your channels and deploy the fastest improvements.</p>
+        <div class="cta-actions">
+          <a class="btn" href="mailto:Emnet@emnetcm.com">Email EmNet</a>
+          <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">Telegram: EmnetCm</a>
+        </div>
+      </div>
+    </section>
+
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+
     <section id="about" class="container section">
       <h2>About</h2>
       <p>EmNet manages the backbone of online communities. From scalable moderation to purpose-built tools and reporting. Growth that reflects reality.</p>
       <a class="btn" href="about.html">Learn more</a>
     </section>
 
-    <section id="contact" class="container section">
-      <h2>Get in touch</h2>
-      <p>Tell us what is not working in your channels. We will suggest practical fixes.</p>
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+
+    <section id="contact" class="container section final-cta">
+      <h2>Next step</h2>
+      <p>Tell us what is not working in your channels. We will map the fastest fix.</p>
       <div class="cta-actions">
         <a class="btn" href="mailto:Emnet@emnetcm.com">Email EmNet</a>
-        <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a>
+        <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">Telegram: EmnetCm</a>
       </div>
     </section>
   </main>
@@ -75,6 +112,7 @@
       <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
     </div>
   </footer>
+  <script src="assets/site.js" defer></script>
   <script>
     document.querySelectorAll('.js-current-year').forEach(function (el) {
       el.textContent = new Date().getFullYear();

--- a/styles/main.css
+++ b/styles/main.css
@@ -115,6 +115,11 @@ body.about-page .hero-logo {
   color: #000;
 }
 
+.btn:focus-visible {
+  outline: 2px solid #ff2ebd;
+  outline-offset: 3px;
+}
+
 .cta-actions {
   display: flex;
   flex-wrap: wrap;
@@ -136,6 +141,143 @@ body.about-page .hero-logo {
 
 .section h2 {
   color: #ff2ebd; /* neon pink section headers */
+}
+
+.section p {
+  color: #d0d0d0;
+}
+
+.trust-strip {
+  background: #0d0d0d;
+  border-block: 1px solid #222;
+}
+
+.trust-strip h2 {
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.trust-metrics {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.trust-metric {
+  padding: 24px;
+  border: 1px solid #222;
+  border-radius: 16px;
+  background: #151515;
+}
+
+.trust-metric-heading {
+  margin: 0 0 12px;
+  font-size: 20px;
+  font-weight: 700;
+  color: #e4e4e4;
+}
+
+.metric-number {
+  display: inline-block;
+  margin-right: 6px;
+  font-size: 28px;
+  font-weight: 700;
+  color: #a8a8a8;
+  transition: color 0.3s ease;
+}
+
+.metric-number.is-active {
+  color: #ff2ebd;
+}
+
+.metric-detail {
+  margin: 0;
+  color: #bdbdbd;
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.ais-heading {
+  color: #cccccc;
+  transition: color 0.3s ease;
+}
+
+.ais-heading.is-active {
+  color: #ff2ebd;
+}
+
+.ais-bridge {
+  margin-top: 32px;
+  padding: 24px;
+  border: 1px solid #222;
+  border-radius: 16px;
+  background: #151515;
+}
+
+.ais-bridge h2 {
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.ais-bridge p {
+  margin: 0;
+  color: #dcdcdc;
+}
+
+.cta-mid {
+  background: linear-gradient(90deg, rgba(255, 46, 189, 0.15) 0%, rgba(0, 0, 0, 0.75) 100%);
+  text-align: center;
+}
+
+.cta-mid h2 {
+  color: #ffffff;
+  margin-bottom: 12px;
+}
+
+.cta-mid p {
+  margin: 0 auto;
+  max-width: 520px;
+}
+
+.final-cta {
+  text-align: center;
+  background: #111;
+  border: 1px solid #222;
+  border-radius: 24px;
+  padding: 48px 24px;
+}
+
+.final-cta h2 {
+  color: #ffffff;
+  margin-bottom: 12px;
+}
+
+.final-cta p {
+  margin: 0 auto;
+  max-width: 520px;
+}
+
+.individual-services ul {
+  list-style: none;
+  margin: 24px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.individual-services li {
+  border: 1px solid #333;
+  border-radius: 12px;
+  padding: 16px;
+  background: #1a1a1a;
+  color: #dddddd;
+}
+
+.individual-services li strong {
+  display: block;
+  margin-bottom: 8px;
+  color: #ff2ebd;
 }
 
 .workflow-section {
@@ -264,5 +406,16 @@ body.about-page .hero-logo {
 
   .workflow-section {
     padding: 100px 0;
+  }
+
+  .final-cta {
+    padding: 40px 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .metric-number,
+  .ais-heading {
+    transition: none;
   }
 }


### PR DESCRIPTION
## Summary
- add trust metrics strip, mid-page CTA, and updated final CTA on the homepage
- add AIS bridge, refreshed individual services, and aligned CTA on the how we work page
- implement scroll-based highlighting with Intersection Observer and supporting styles/assets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddbd055e808322a5b7b41f2f12483e