### PR TITLE
Refine CTA sections and scroll highlighting

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,11 +9,11 @@
   <meta property="og:description" content="Discover the team, philosophy, and operational principles behind EmNet Community Management Limited.">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="EmNet Community Management Limited">
-  <meta property="og:image" content="assets/og-image.png">
+  <meta property="og:image" content="assets/logo.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="About EmNet | EmNet Community Management Limited.">
   <meta name="twitter:description" content="Discover the team, philosophy, and operational principles behind EmNet Community Management Limited.">
-  <meta name="twitter:image" content="assets/og-image.png">
+  <meta name="twitter:image" content="assets/logo.png">
   <link rel="icon" href="assets/favicon.png">
   <link rel="stylesheet" href="styles/main.css">
 </head>
@@ -26,7 +26,7 @@
         <a href="about.html" aria-current="page">About</a>
         <a href="index.html#services">Services</a>
         <a href="how-we-work.html">How we work</a>
-        <a href="index.html#contact">Contact</a>
+        <a href="index.html#next-step">Contact</a>
       </nav>
     </div>
   </header>
@@ -37,7 +37,7 @@
         <img src="assets/logo.png" alt="EmNet logo" class="hero-logo">
         <h1>About EmNet</h1>
         <p>Building sustainable, high-trust communities for projects that value long-term impact.</p>
-        <a class="btn" href="index.html#contact">Contact us</a>
+        <a class="btn" href="index.html#next-step">Contact us</a>
       </div>
     </section>
 
@@ -65,10 +65,6 @@
       <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
     </div>
   </footer>
-  <script>
-    document.querySelectorAll('.js-current-year').forEach(function (el) {
-      el.textContent = new Date().getFullYear();
-    });
-  </script>
+  <script src="assets/site.js"></script>
 </body>
 </html>

--- a/assets/site.js
+++ b/assets/site.js
@@ -1,0 +1,92 @@
+(function () {
+  var yearEls = document.querySelectorAll('.js-current-year');
+  var currentYear = new Date().getFullYear();
+  yearEls.forEach(function (el) {
+    el.textContent = currentYear;
+  });
+
+  var highlightTargets = Array.prototype.slice.call(
+    document.querySelectorAll('.metric-number, .ais-heading')
+  );
+
+  if (!highlightTargets.length) {
+    return;
+  }
+
+  var motionQuery = null;
+  if (window.matchMedia) {
+    motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  }
+
+  var observer = null;
+
+  function setStaticState() {
+    if (observer && typeof observer.disconnect === 'function') {
+      observer.disconnect();
+    }
+    observer = null;
+    highlightTargets.forEach(function (el) {
+      el.classList.add('is-active');
+    });
+  }
+
+  function setDynamicState() {
+    if (!('IntersectionObserver' in window)) {
+      setStaticState();
+      return;
+    }
+
+    if (observer && typeof observer.disconnect === 'function') {
+      observer.disconnect();
+    }
+
+    highlightTargets.forEach(function (el) {
+      el.classList.remove('is-active');
+    });
+
+    observer = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-active');
+          } else {
+            entry.target.classList.remove('is-active');
+          }
+        });
+      },
+      {
+        root: null,
+        rootMargin: '-33% 0px -33% 0px',
+        threshold: 0.5
+      }
+    );
+
+    highlightTargets.forEach(function (el) {
+      observer.observe(el);
+    });
+  }
+
+  function handlePreferenceChange(event) {
+    if (event.matches) {
+      setStaticState();
+    } else {
+      setDynamicState();
+    }
+  }
+
+  if (motionQuery && typeof motionQuery.matches === 'boolean') {
+    if (motionQuery.matches) {
+      setStaticState();
+    } else {
+      setDynamicState();
+    }
+
+    if (typeof motionQuery.addEventListener === 'function') {
+      motionQuery.addEventListener('change', handlePreferenceChange);
+    } else if (typeof motionQuery.addListener === 'function') {
+      motionQuery.addListener(handlePreferenceChange);
+    }
+  } else {
+    setDynamicState();
+  }
+})();

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -9,11 +9,11 @@
   <meta property="og:description" content="See how EmNet Community Management Limited audits, implements, and sustains resilient Web3 communities.">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="EmNet Community Management Limited">
-  <meta property="og:image" content="assets/og-image.png">
+  <meta property="og:image" content="assets/logo.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="How we work | EmNet Community Management Limited.">
   <meta name="twitter:description" content="See how EmNet Community Management Limited audits, implements, and sustains resilient Web3 communities.">
-  <meta name="twitter:image" content="assets/og-image.png">
+  <meta name="twitter:image" content="assets/logo.png">
   <link rel="icon" href="assets/favicon.png">
   <link rel="stylesheet" href="styles/main.css">
 </head>
@@ -26,7 +26,7 @@
         <a href="about.html">About</a>
         <a href="index.html#services">Services</a>
         <a href="how-we-work.html" aria-current="page">How we work</a>
-        <a href="index.html#contact">Contact</a>
+        <a href="index.html#next-step">Contact</a>
       </nav>
     </div>
   </header>
@@ -48,6 +48,13 @@
       </div>
     </section>
 
+    <section class="container ais-bridge" aria-labelledby="ais-bridge-title">
+      <h2 id="ais-bridge-title">AIS</h2>
+      <p>AIS is our full framework: Audit, Implement, Sustain. It starts with a hands-on review, then structured improvements and long-term stability.</p>
+    </section>
+
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+
     <section class="section workflow-section workflow-section--audit" id="audit">
       <div class="container workflow-content">
         <nav class="workflow-shortcuts" aria-label="Workflow shortcuts">
@@ -57,7 +64,7 @@
           <span aria-hidden="true">&gt;</span>
           <a href="#sustain">Sustain</a>
         </nav>
-        <h2>Audit</h2>
+        <h2 class="ais-heading">Audit</h2>
         <p><strong>Purpose:</strong> Experience your community as a member would, then map the systems behind it.</p>
         <h3>What we do</h3>
         <ul>
@@ -83,7 +90,7 @@
 
     <section class="section workflow-section workflow-section--implement" id="implement">
       <div class="container workflow-content">
-        <h2>Implement</h2>
+        <h2 class="ais-heading">Implement</h2>
         <p><strong>Purpose:</strong> Deploy processes, automation, and playbooks that stabilise your community.</p>
         <h3>What we do</h3>
         <ul>
@@ -108,7 +115,7 @@
 
     <section class="section workflow-section workflow-section--sustain" id="sustain">
       <div class="container workflow-content">
-        <h2>Sustain</h2>
+        <h2 class="ais-heading">Sustain</h2>
         <p><strong>Purpose:</strong> Keep systems running smoothly and evolving with the community.</p>
         <h3>What we do</h3>
         <ul>
@@ -132,24 +139,23 @@
 
     <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
 
-    <section class="container section">
-      <h2>Additional services</h2>
-      <p>Alongside AIS and individual stages, EmNet also offers:</p>
-      <ul>
-        <li><strong>Custom bot builds</strong> — developed to order for your specific needs.</li>
-        <li><strong>Bluesky analytics reports</strong> — provide a username and timeframe for a quick, clear engagement report.</li>
-        <li><strong>Standard moderation</strong> — professional coverage at a reasonable rate.</li>
+    <section class="container section individual-services" id="individual-services">
+      <h2>Individual services</h2>
+      <ul class="services-list">
+        <li><strong>Custom bot builds</strong> — built to order for your needs</li>
+        <li><strong>Bluesky analytics reports</strong> — send a username and timeframe for a clear engagement report</li>
+        <li><strong>Standard moderation</strong> — reliable coverage at a reasonable rate</li>
       </ul>
     </section>
 
     <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
 
-    <section class="container section">
+    <section id="next-step" class="container section final-cta">
       <h2>Next step</h2>
-      <p>Ready to strengthen your community operations? Reach out and we will map the next actionable step together.</p>
+      <p>Tell us what is not working in your channels. We will map the fastest fix.</p>
       <div class="cta-actions">
         <a class="btn" href="mailto:Emnet@emnetcm.com">Email EmNet</a>
-        <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a>
+        <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">Telegram: EmnetCm</a>
       </div>
     </section>
   </main>
@@ -163,10 +169,6 @@
       <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
     </div>
   </footer>
-  <script>
-    document.querySelectorAll('.js-current-year').forEach(function (el) {
-      el.textContent = new Date().getFullYear();
-    });
-  </script>
+  <script src="assets/site.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,11 +9,11 @@
   <meta property="og:description" content="Community operations, automation, and analytics that keep Web3 ecosystems running smoothly.">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="EmNet Community Management Limited">
-  <meta property="og:image" content="assets/og-image.png">
+  <meta property="og:image" content="assets/logo.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="EmNet Community Management Limited | Community operations for Web3.">
   <meta name="twitter:description" content="Community operations, automation, and analytics that keep Web3 ecosystems running smoothly.">
-  <meta name="twitter:image" content="assets/og-image.png">
+  <meta name="twitter:image" content="assets/logo.png">
   <link rel="icon" href="assets/favicon.png">
   <link rel="stylesheet" href="styles/main.css">
 </head>
@@ -26,7 +26,7 @@
         <a href="about.html">About</a>
         <a href="#services">Services</a>
         <a href="how-we-work.html">How we work</a>
-        <a href="#contact">Contact</a>
+        <a href="#next-step">Contact</a>
       </nav>
     </div>
   </header>
@@ -37,7 +37,7 @@
         <img src="assets/logo.png" alt="EmNet logo" class="hero-logo">
         <h1>EmNet Community Management Ltd</h1>
         <p>Operational excellence for social platforms. Telegram, and on-chain community tooling.</p>
-        <a class="btn" href="#contact">Get in touch</a>
+        <a class="btn" href="#next-step">Get in touch</a>
       </div>
     </section>
 
@@ -50,18 +50,50 @@
       </ul>
     </section>
 
+    <section id="trust" class="trust-strip">
+      <div class="container trust-strip__grid">
+        <article class="trust-item">
+          <p><span class="metric-number">90%</span> spam reduction</p>
+          <p>in a 30k-member group, four weeks after new bot configuration</p>
+        </article>
+        <article class="trust-item">
+          <p><span class="metric-number">3h → 20min</span> response time</p>
+          <p>median time to first helpful reply</p>
+        </article>
+        <article class="trust-item">
+          <p><span class="metric-number">+42%</span> contributor growth</p>
+          <p>month over month after playbook rollout</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="cta-mid" class="cta-strip">
+      <div class="container cta-strip__inner">
+        <div>
+          <h2>Ready for accountable community ops?</h2>
+          <p>We stabilise fast-moving channels with automation, reporting, and human coverage.</p>
+        </div>
+        <div class="cta-actions">
+          <a class="btn" href="mailto:Emnet@emnetcm.com">Email EmNet</a>
+          <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">Telegram: EmnetCm</a>
+        </div>
+      </div>
+    </section>
+
     <section id="about" class="container section">
       <h2>About</h2>
       <p>EmNet manages the backbone of online communities. From scalable moderation to purpose-built tools and reporting. Growth that reflects reality.</p>
       <a class="btn" href="about.html">Learn more</a>
     </section>
 
-    <section id="contact" class="container section">
-      <h2>Get in touch</h2>
-      <p>Tell us what is not working in your channels. We will suggest practical fixes.</p>
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+
+    <section id="next-step" class="container section final-cta">
+      <h2>Next step</h2>
+      <p>Tell us what is not working in your channels. We will map the fastest fix.</p>
       <div class="cta-actions">
         <a class="btn" href="mailto:Emnet@emnetcm.com">Email EmNet</a>
-        <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a>
+        <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">Telegram: EmnetCm</a>
       </div>
     </section>
   </main>
@@ -75,10 +107,6 @@
       <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
     </div>
   </footer>
-  <script>
-    document.querySelectorAll('.js-current-year').forEach(function (el) {
-      el.textContent = new Date().getFullYear();
-    });
-  </script>
+  <script src="assets/site.js"></script>
 </body>
 </html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -115,11 +115,42 @@ body.about-page .hero-logo {
   color: #000;
 }
 
+.btn:focus-visible {
+  outline: 3px solid #ffffff;
+  outline-offset: 2px;
+  background: #ff2ebd;
+  color: #000;
+}
+
 .cta-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
   margin-top: 16px;
+}
+
+.cta-strip {
+  background: linear-gradient(135deg, rgba(255, 46, 189, 0.2), rgba(255, 46, 189, 0.05));
+  border-block: 1px solid rgba(255, 46, 189, 0.3);
+  padding: 48px 0;
+}
+
+.cta-strip__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.cta-strip h2 {
+  margin: 0 0 8px;
+  color: #ffffff;
+}
+
+.cta-strip p {
+  margin: 0;
+  color: #d6d6d6;
+  max-width: 520px;
 }
 
 .section-divider {
@@ -136,6 +167,11 @@ body.about-page .hero-logo {
 
 .section h2 {
   color: #ff2ebd; /* neon pink section headers */
+}
+
+.ais-heading {
+  color: #d0d0d0;
+  transition: color 0.3s ease;
 }
 
 .workflow-section {
@@ -200,6 +236,92 @@ body.about-page .hero-logo {
   text-decoration: underline;
 }
 
+.trust-strip {
+  padding: 56px 0;
+  background: #0a0a0a;
+}
+
+.trust-strip__grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.trust-item {
+  padding: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  background: rgba(17, 17, 17, 0.8);
+}
+
+.trust-item p {
+  margin: 0 0 8px;
+  color: #bcbcbc;
+}
+
+.trust-item p:last-child {
+  margin-bottom: 0;
+}
+
+.metric-number {
+  display: inline-block;
+  margin-right: 6px;
+  font-size: 24px;
+  font-weight: 700;
+  color: #9a9a9a;
+  transition: color 0.3s ease;
+}
+
+.ais-bridge {
+  padding: 40px 0 16px;
+}
+
+.ais-bridge h2 {
+  margin-top: 0;
+  color: #ff2ebd;
+}
+
+.ais-bridge p {
+  color: #d6d6d6;
+  max-width: 720px;
+}
+
+.services-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.services-list li {
+  padding: 16px 20px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  background: rgba(17, 17, 17, 0.8);
+  color: #dcdcdc;
+}
+
+.services-list strong {
+  color: #ffffff;
+}
+
+.final-cta {
+  text-align: center;
+}
+
+.final-cta p {
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+  color: #d6d6d6;
+}
+
+.is-active {
+  color: #ff2ebd !important;
+}
+
 .workflow-shortcuts span {
   color: #666666;
 }
@@ -260,6 +382,24 @@ body.about-page .hero-logo {
 
   .hero h1 {
     font-size: 32px;
+  }
+
+  .cta-strip__inner {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .cta-strip p {
+    max-width: none;
+  }
+
+  .final-cta {
+    text-align: center;
+  }
+
+  .trust-strip__grid,
+  .services-list {
+    grid-template-columns: 1fr;
   }
 
   .workflow-section {


### PR DESCRIPTION
## Summary
- reposition the homepage trust metrics and CTA strip while updating contact buttons to the requested targets
- scope the metric highlight class to the numeric spans, adjust supporting styles, and remove the generated og-image asset in favour of the existing logo
- extend the shared script to respect prefers-reduced-motion with static highlights and reuse it across pages via a single include

## Testing
- python -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68ddb9595fdc83228e5aeda3c9746a1b