### PR TITLE
Update about page imagery and messaging

### DIFF
--- a/about.html
+++ b/about.html
@@ -42,7 +42,7 @@
   <main>
     <section class="hero">
       <div class="container">
-        <img src="assets/logo.png" alt="EmNet logo" class="hero-logo">
+        <img src="assets/AboutUs.png" alt="Illustration of the EmNet founder" class="hero-logo">
         <h1>About EmNet</h1>
         <p>Building sustainable, high-trust communities for projects that value long-term impact.</p>
         <a class="btn" href="index.html#contact">Contact us</a>
@@ -50,7 +50,7 @@
     </section>
 
     <section class="container section">
-      <h2 class="ais-heading scroll-animate">Operational community growth</h2>
+      <h2 class="ais-heading scroll-animate">A Note From Our Founder</h2>
       <p>EmNet Community Management Limited specialises in building sustainable, high-trust communities for projects that want more than short-term hype.</p>
       <p>It is easy to make numbers rise. Followers can be bought, giveaways can be run, and spikes can be manufactured. But real community is measured differently. It is measured by whether people feel welcome, whether their questions are answered, whether they return, and whether they contribute. A thousand inflated accounts will never equal a hundred active, genuine participants.</p>
       <p>At EmNet we recognise that numbers are still important — but they only have value when they represent real people. Our role is to give authenticity to those numbers by ensuring growth is grounded in genuine engagement and meaningful interaction. When a community count rises under our management, it reflects actual presence, not empty hype.</p>
@@ -61,6 +61,7 @@
         <li>Analytics and reporting that highlight substance — retention, resolved issues, depth of engagement — rather than vanity metrics.</li>
       </ul>
       <p>This work is often invisible, but it is what sustains a community once the marketing cycle has passed. By focusing on operational discipline, cultural clarity, and the human side of interaction, EmNet ensures communities remain credible, valuable, and durable.</p>
+      <img src="assets/sig.png" alt="Signature of EmNet's founder" class="founder-signature">
     </section>
   </main>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -132,7 +132,7 @@ body {
 }
 
 body.about-page .hero-logo {
-  width: min(130px, 35vw);
+  width: min(420px, 90vw);
 }
 
 .hero h1 {
@@ -214,6 +214,14 @@ body.about-page .hero-logo {
 
 .section p {
   color: #d0d0d0;
+}
+
+.founder-signature {
+  display: block;
+  margin: 24px 0 0;
+  max-width: 220px;
+  width: 100%;
+  height: auto;
 }
 
 .trust-strip {


### PR DESCRIPTION
## Summary
- swap the About page hero artwork to the new AboutUs image and update the heading copy to introduce the founder letter
- add the founder signature graphic and supporting styles so the message reads like a signed note

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dddb60a24483229dc1d3ed5d34da42