### PR TITLE
Make About page hero banner full width

### DIFF
--- a/about.html
+++ b/about.html
@@ -40,12 +40,16 @@
   </header>
 
   <main>
-    <section class="hero">
-      <div class="container">
-        <img src="assets/AboutUs.png" alt="Illustration of the EmNet founder" class="hero-logo">
-        <h1>About Us</h1>
-        <p>Building sustainable, high-trust communities for projects that value long-term impact.</p>
-        <a class="btn" href="index.html#contact">Contact us</a>
+    <section class="hero hero-about">
+      <div class="hero-banner">
+        <img src="assets/AboutUs.png" alt="Illustration of the EmNet founder" class="hero-banner-image">
+        <div class="hero-banner-content">
+          <div class="container">
+            <h1>About Us</h1>
+            <p>Building sustainable, high-trust communities for projects that value long-term impact.</p>
+            <a class="btn" href="index.html#contact">Contact us</a>
+          </div>
+        </div>
       </div>
     </section>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -124,6 +124,67 @@ body {
   text-align: center;
 }
 
+.hero-about {
+  padding: 0;
+  background: transparent;
+}
+
+.hero-banner {
+  position: relative;
+  width: 100%;
+}
+
+.hero-banner-image {
+  display: block;
+  width: 100%;
+  height: clamp(280px, 45vw, 520px);
+  object-fit: cover;
+}
+
+.hero-banner::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.45) 0%, rgba(0, 0, 0, 0.65) 100%);
+}
+
+.hero-banner-content {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 40px 20px;
+}
+
+.hero-banner-content .container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.hero-about h1 {
+  font-size: clamp(42px, 5vw, 64px);
+  margin-bottom: 0;
+}
+
+.hero-about p {
+  max-width: 760px;
+  color: #e5e5e5;
+}
+
+.hero-about .btn {
+  border-color: #ffffff;
+  color: #ffffff;
+}
+
+.hero-about .btn:hover {
+  background: #ffffff;
+  color: #000000;
+}
+
 .hero-logo {
   display: block;
   margin: 0 auto 32px;


### PR DESCRIPTION
## Summary
- expand the About page hero into a full-width banner with responsive scaling
- overlay the About Us heading, copy, and call-to-action on top of the banner for better emphasis

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dde140442c8322b05b44dcff597551