### PR TITLE
Adjust founder signature alignment on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -53,7 +53,7 @@
       </div>
     </section>
 
-    <section class="container section">
+    <section class="container section founder-note">
       <h2 class="ais-heading scroll-animate">A Note From Our Founder</h2>
       <p>EmNet Community Management Limited specialises in building sustainable, high-trust communities for projects that want more than short-term hype.</p>
       <p>It is easy to make numbers rise. Followers can be bought, giveaways can be run, and spikes can be manufactured. But real community is measured differently. It is measured by whether people feel welcome, whether their questions are answered, whether they return, and whether they contribute. A thousand inflated accounts will never equal a hundred active, genuine participants.</p>

--- a/styles/main.css
+++ b/styles/main.css
@@ -283,10 +283,18 @@ body.about-page .hero-logo {
 
 .founder-signature {
   display: block;
-  margin: 24px 0 0;
+  margin: 12px 0 0 auto;
   max-width: 220px;
   width: 100%;
   height: auto;
+}
+
+.founder-note p:last-of-type {
+  margin-bottom: 8px;
+}
+
+.founder-note .founder-signature {
+  margin-top: 4px;
 }
 
 .trust-strip {


### PR DESCRIPTION
## Summary
- add a section-specific hook to the founder note for targeted layout adjustments
- tighten spacing and right-align the signature image so it sits closer to the closing copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dde42c8a5c832283fd50ddc9f25504