### PR TITLE
Add dedicated services page and styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,7 +32,7 @@
       <nav class="nav" id="primary-nav">
         <a href="index.html">Home</a>
         <a href="about.html" aria-current="page">About</a>
-        <a href="index.html#services">Services</a>
+        <a href="services.html">Services</a>
         <a href="how-we-work.html">How we work</a>
         <a href="index.html#contact">Contact</a>
       </nav>

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -32,7 +32,7 @@
       <nav class="nav" id="primary-nav">
         <a href="index.html">Home</a>
         <a href="about.html">About</a>
-        <a href="index.html#services">Services</a>
+        <a href="services.html">Services</a>
         <a href="how-we-work.html" aria-current="page">How we work</a>
         <a href="#contact">Contact</a>
       </nav>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       <nav class="nav" id="primary-nav">
         <a href="index.html" aria-current="page">Home</a>
         <a href="about.html">About</a>
-        <a href="#services">Services</a>
+        <a href="services.html">Services</a>
         <a href="how-we-work.html">How we work</a>
         <a href="#contact">Contact</a>
       </nav>

--- a/services.html
+++ b/services.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Services | EmNet Community Management Limited.</title>
+  <meta name="description" content="Explore EmNet's moderation, automation, analytics, and AIS service packages for resilient communities.">
+  <meta property="og:title" content="Services | EmNet Community Management Limited.">
+  <meta property="og:description" content="Explore EmNet's moderation, automation, analytics, and AIS service packages for resilient communities.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="EmNet Community Management Limited">
+  <meta property="og:image" content="assets/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Services | EmNet Community Management Limited.">
+  <meta name="twitter:description" content="Explore EmNet's moderation, automation, analytics, and AIS service packages for resilient communities.">
+  <meta name="twitter:image" content="assets/og-image.png">
+  <link rel="icon" href="assets/favicon.png">
+  <link rel="stylesheet" href="styles/main.css">
+</head>
+<body class="services-page">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="index.html" class="logo-link" aria-label="EmNet home">
+        <img src="assets/logo.png" alt="EmNet logo" class="logo">
+      </a>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+      </button>
+      <nav class="nav" id="primary-nav">
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="services.html" aria-current="page">Services</a>
+        <a href="how-we-work.html">How we work</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero hero-about hero-services">
+      <div class="hero-banner">
+        <img src="assets/services-banner.png" alt="Services banner for EmNet" class="hero-banner-image">
+        <div class="hero-banner-content">
+          <div class="container">
+            <h1>Our Services</h1>
+            <p>From a single moderator to full-scale operations, we make communities stable, safe, and measurable.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="services-primary section">
+      <div class="container">
+        <article class="services-primary-card">
+          <header class="services-primary-header">
+            <h2 class="scroll-animate">I Need a Mod</h2>
+            <p class="services-primary-price">$500 – $750 per calendar month <span>(negotiable depending on terms)</span></p>
+          </header>
+          <p>A dedicated moderator to keep your community responsive and safe. Clear coverage hours, consistent presence, and escalation when needed.</p>
+          <ul class="services-primary-list">
+            <li>Coverage defined by contract (number of hours / shifts).</li>
+            <li>Available for Telegram, Bluesky, or hybrid setups.</li>
+            <li>Quick onboarding: we’ll align on rules, tone, and escalation path.</li>
+          </ul>
+          <a class="btn" href="mailto:Emnet@emnetcm.com">Contract a moderator</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="section services-grid-section">
+      <div class="container">
+        <h2 class="scroll-animate">Core services on demand</h2>
+        <div class="service-grid">
+          <article class="service-card">
+            <h3>Community Operations Audit</h3>
+            <p>We join your group, experience it as a user, and map every system in place. Bots, data capture, risks, and quick wins are all documented in a plain-English report.</p>
+            <p class="service-price">One-off charge: from $150.</p>
+            <p class="service-detail">Deliverable: written audit + debrief call.</p>
+          </article>
+          <article class="service-card">
+            <h3>Custom Bot Development</h3>
+            <p>Tailored automation built for your exact needs. Onboarding flows, quizzes, broadcast bots, XP systems, or compliance checks — built to order.</p>
+            <p class="service-price">One-off charge: from $750.</p>
+            <p class="service-detail">Ongoing support/updates available on request.</p>
+          </article>
+          <article class="service-card">
+            <h3>Analytics &amp; Reporting</h3>
+            <p>Reports that measure reality, not vanity. Retention, solved issues, response time, contributor growth — sent monthly or quarterly.</p>
+            <p class="service-price">One-off report: from $25 for Bluesky. One month report for Telegram: $50.</p>
+            <p class="service-detail">Subscription option: discounted rates for recurring reports.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="ais-highlight">
+      <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true">
+      <div class="container ais-highlight-content">
+        <h2 class="scroll-animate">AIS: Audit, Implement, Sustain</h2>
+        <p>For projects that need more than a quick fix. AIS is our complete framework: we start with a deep audit, deliver structural improvements, and provide ongoing stability with automated features like custom quizzes.</p>
+        <p class="ais-price">From $1,000 initial (price scales with community size and scope) then optional $500 monthly on a month-by-month basis.</p>
+        <p class="ais-detail">Tailored contract covering all three phases.</p>
+        <a class="btn" href="mailto:Emnet@emnetcm.com">Discuss AIS</a>
+      </div>
+    </section>
+
+    <section class="container section services-addons">
+      <h2 class="scroll-animate">Targeted add-ons</h2>
+      <ul>
+        <li><strong>Bluesky Analytics Reports</strong> — Takes all posts from the existing Bluesky account and measures engagement activity. Can report on likes, shares, content buzzwords and more.</li>
+        <li><strong>BD Buddy Broadcast Bot</strong> — Push reports and announcements into multiple groups at once, perfect for BD professionals on Telegram.</li>
+        <li><strong>Standard Moderation (per shift)</strong> — Ad-hoc cover at a reasonable rate (rates begin at $500 per month and scale based on scope/demand).</li>
+      </ul>
+      <p class="services-addons-note">Add-ons can be contracted separately or layered on top of AIS.</p>
+    </section>
+
+    <section class="section services-examples">
+      <div class="container">
+        <h2 class="scroll-animate">What this looks like in practice</h2>
+        <div class="service-grid">
+          <article class="service-card">
+            <h3>Sign-in Bot</h3>
+            <p>Tracks moderator team activity and generates individual reports. Shows who is covering shifts and where gaps appear.</p>
+          </article>
+          <article class="service-card">
+            <h3>Quiz Bot</h3>
+            <p>Delivers company-specific quizzes that both educate and engage. Fully automated and sustainable.</p>
+          </article>
+          <article class="service-card">
+            <h3>BD Buddy</h3>
+            <p>Broadcasts company updates, investor reports, or announcements into multiple chats reliably and at scale.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section final-cta services-final-cta">
+      <div class="container">
+        <h2 class="scroll-animate">Ready to choose the service that fits?</h2>
+        <div class="cta-actions">
+          <a class="btn" href="mailto:Emnet@emnetcm.com">Email EmNet</a>
+          <a class="btn" href="https://t.me/millieme85" target="_blank" rel="noopener">Telegram: EmnetCm</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-meta">
+        <small>© <span class="js-current-year"></span> EmNet Community Management Limited</small>
+        <small>Company No. 13716390</small>
+        <small>Registrar of Companies for England and Wales</small>
+        <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
+        <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
+      </div>
+      <ul class="footer-social" aria-label="Contact and social links">
+        <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
+        <li><a href="https://x.com/EmnetCm" target="_blank" rel="noopener"><img src="assets/xlogo.png" alt="X"></a></li>
+        <li><a href="https://t.me/millieme85" target="_blank" rel="noopener"><img src="assets/tglogo.png" alt="Telegram"></a></li>
+      </ul>
+    </div>
+  </footer>
+  <script src="assets/site.js" defer></script>
+  <script>
+    document.querySelectorAll('.js-current-year').forEach(function (el) {
+      el.textContent = new Date().getFullYear();
+    });
+  </script>
+</body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -189,6 +189,74 @@ body {
   color: #000000;
 }
 
+.services-primary {
+  padding: clamp(56px, 8vw, 96px) 0;
+}
+
+.services-primary-card {
+  background: linear-gradient(145deg, rgba(255, 46, 189, 0.16) 0%, rgba(19, 19, 19, 0.96) 62%, rgba(0, 0, 0, 0.96) 100%);
+  border: 1px solid rgba(255, 46, 189, 0.35);
+  border-radius: 24px;
+  padding: clamp(28px, 6vw, 48px);
+  display: grid;
+  gap: clamp(18px, 3vw, 24px);
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.4);
+}
+
+.services-primary-card > p {
+  margin: 0;
+  color: #e6e6e6;
+  line-height: 1.6;
+}
+
+.services-primary-header {
+  display: grid;
+  gap: 12px;
+}
+
+.services-primary-header h2 {
+  margin: 0;
+  font-size: clamp(30px, 4vw, 42px);
+}
+
+.services-primary-price {
+  margin: 0;
+  font-weight: 600;
+  color: #ff71d5;
+}
+
+.services-primary-price span {
+  display: block;
+  font-weight: 400;
+  font-size: 14px;
+  color: #cfcfcf;
+}
+
+.services-primary-list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+  color: #dcdcdc;
+  line-height: 1.6;
+  list-style: disc;
+}
+
+.services-primary-card .btn {
+  align-self: start;
+  padding: 12px 22px;
+  font-weight: 600;
+  background: #ff2ebd;
+  border-color: #ff2ebd;
+  color: #000000;
+}
+
+.services-primary-card .btn:hover {
+  background: #ff5bd0;
+  border-color: #ff5bd0;
+  color: #000000;
+}
+
 .hero-logo {
   display: block;
   margin: 0 auto 32px;
@@ -376,6 +444,137 @@ body.about-page .hero-logo {
 .cta-mid p {
   margin: 0 auto;
   max-width: 520px;
+}
+
+.services-grid-section {
+  background: #0c0c0c;
+  border-block: 1px solid #1d1d1d;
+}
+
+.services-grid-section .container,
+.services-examples .container {
+  display: grid;
+  gap: clamp(24px, 4vw, 40px);
+}
+
+.service-grid {
+  display: grid;
+  gap: clamp(18px, 3vw, 28px);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.service-card {
+  background: #151515;
+  border: 1px solid #262626;
+  border-radius: 16px;
+  padding: clamp(18px, 3vw, 26px);
+  display: grid;
+  gap: 12px;
+  color: #d8d8d8;
+}
+
+.service-card h3 {
+  margin: 0;
+  font-size: clamp(20px, 2.6vw, 24px);
+  color: #ffffff;
+}
+
+.service-card p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.service-price {
+  font-weight: 600;
+  color: #ff2ebd;
+}
+
+.service-detail {
+  color: #bcbcbc;
+  font-size: 15px;
+}
+
+.ais-highlight {
+  background: #050505;
+  padding: clamp(48px, 8vw, 96px) 0 clamp(56px, 9vw, 96px);
+  border-top: 1px solid #1d1d1d;
+  border-bottom: 1px solid #1d1d1d;
+  text-align: center;
+}
+
+.ais-highlight .section-divider {
+  margin-top: 0;
+  margin-bottom: clamp(24px, 4vw, 32px);
+}
+
+.ais-highlight-content {
+  display: grid;
+  gap: clamp(18px, 3vw, 26px);
+  max-width: 760px;
+  text-align: center;
+}
+
+.ais-highlight-content p {
+  margin: 0;
+  color: #dcdcdc;
+  line-height: 1.6;
+}
+
+.ais-price {
+  font-weight: 600;
+  color: #ff2ebd;
+}
+
+.ais-detail {
+  color: #b5b5b5;
+}
+
+.ais-highlight .btn {
+  justify-self: center;
+}
+
+.services-addons ul {
+  margin: 24px 0 0;
+  padding-left: 22px;
+  display: grid;
+  gap: 16px;
+  color: #d6d6d6;
+  list-style: disc;
+}
+
+.services-addons li {
+  line-height: 1.6;
+}
+
+.services-addons strong {
+  color: #ff2ebd;
+}
+
+.services-addons-note {
+  margin-top: 20px;
+  color: #bcbcbc;
+  font-size: 15px;
+}
+
+.services-examples {
+  background: #0c0c0c;
+  border-top: 1px solid #1d1d1d;
+  border-bottom: 1px solid #1d1d1d;
+}
+
+.services-examples .service-card {
+  background: #141414;
+}
+
+.services-final-cta {
+  border: 1px solid #1f1f1f;
+  border-radius: 24px;
+  background: linear-gradient(120deg, rgba(255, 46, 189, 0.16) 0%, rgba(17, 17, 17, 0.95) 100%);
+  margin: clamp(40px, 8vw, 72px) 20px 0;
+}
+
+.services-final-cta .cta-actions {
+  justify-content: center;
 }
 
 .final-cta {
@@ -666,6 +865,18 @@ body.about-page .hero-logo {
 
   .final-cta {
     padding: 40px 20px;
+  }
+
+  .services-primary {
+    padding: 48px 0;
+  }
+
+  .services-primary-card {
+    padding: 24px;
+  }
+
+  .services-final-cta {
+    margin-inline: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated services.html page covering hero, primary moderation offer, AIS package, add-ons, and final CTA
- extend main stylesheet with cards, highlight, and grid treatments tailored for the services layout while keeping the neon theme
- update site navigation links across existing pages to point to the new services page

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dde8d31b7883228c39bee550f301b5