### PR TITLE
Move cookie banner to top of viewport

### DIFF
--- a/about.html
+++ b/about.html
@@ -106,6 +106,7 @@
         <small>Registrar of Companies for England and Wales</small>
         <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
         <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
+        <small><a href="privacy.html">Privacy Policy</a></small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
@@ -114,6 +115,12 @@
       </ul>
     </div>
   </footer>
+  <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
+    <div class="container cookie-banner__inner">
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <button type="button" class="cookie-banner__button js-cookie-accept">Accept</button>
+    </div>
+  </div>
   <script src="assets/site.js" defer></script>
   <script>
     document.querySelectorAll('.js-current-year').forEach(function (el) {

--- a/assets/site.js
+++ b/assets/site.js
@@ -31,6 +31,67 @@
 })();
 
 (function () {
+  const banner = document.querySelector('.js-cookie-banner');
+  const acceptButton = banner ? banner.querySelector('.js-cookie-accept') : null;
+  const storageKey = 'emnetCookieConsent';
+  const root = document.documentElement;
+
+  if (!banner || !acceptButton) {
+    return;
+  }
+
+  let hasConsent = false;
+
+  try {
+    hasConsent = window.localStorage.getItem(storageKey) === 'true';
+  } catch (error) {
+    hasConsent = false;
+  }
+
+  const updateBannerOffset = () => {
+    if (!banner.classList.contains('is-visible')) {
+      root.style.setProperty('--cookie-banner-height', '0px');
+      return;
+    }
+
+    root.style.setProperty('--cookie-banner-height', `${banner.offsetHeight}px`);
+  };
+
+  const hideBanner = () => {
+    banner.classList.remove('is-visible');
+    document.body.classList.remove('cookie-banner-visible');
+    updateBannerOffset();
+  };
+
+  const showBanner = () => {
+    banner.classList.add('is-visible');
+    updateBannerOffset();
+    document.body.classList.add('cookie-banner-visible');
+  };
+
+  if (!hasConsent) {
+    showBanner();
+  }
+
+  acceptButton.addEventListener('click', () => {
+    try {
+      window.localStorage.setItem(storageKey, 'true');
+    } catch (error) {
+      // Ignore storage errors and continue closing the banner.
+    }
+    hideBanner();
+  });
+
+  window.addEventListener('resize', () => {
+    if (!banner.classList.contains('is-visible')) {
+      return;
+    }
+
+    updateBannerOffset();
+  });
+})();
+
+(function () {
   if (!('IntersectionObserver' in window)) {
     return;
   }

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -229,6 +229,7 @@
         <small>Registrar of Companies for England and Wales</small>
         <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
         <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
+        <small><a href="privacy.html">Privacy Policy</a></small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
@@ -237,6 +238,12 @@
       </ul>
     </div>
   </footer>
+  <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
+    <div class="container cookie-banner__inner">
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <button type="button" class="cookie-banner__button js-cookie-accept">Accept</button>
+    </div>
+  </div>
   <script src="assets/site.js" defer></script>
   <script>
     document.querySelectorAll('.js-current-year').forEach(function (el) {

--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
         <small>Registrar of Companies for England and Wales</small>
         <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
         <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
+        <small><a href="privacy.html">Privacy Policy</a></small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
@@ -156,6 +157,12 @@
       </ul>
     </div>
   </footer>
+  <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
+    <div class="container cookie-banner__inner">
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <button type="button" class="cookie-banner__button js-cookie-accept">Accept</button>
+    </div>
+  </div>
   <script src="assets/site.js" defer></script>
   <script>
     document.querySelectorAll('.js-current-year').forEach(function (el) {

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Privacy Policy | EmNet Community Management Limited.</title>
+  <meta name="description" content="Privacy policy for EmNet Community Management Limited, outlining data collection, usage, and contact details.">
+  <meta name="keywords" content="EmNet privacy policy, data protection, cookie consent, EmNet Community Management Limited">
+  <meta name="author" content="EmNet Community Management Limited">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://www.emnetcm.com/privacy">
+  <meta property="og:title" content="Privacy Policy | EmNet Community Management Limited.">
+  <meta property="og:description" content="Learn how EmNet Community Management Limited handles personal data, cookies, and your privacy rights.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="EmNet Community Management Limited">
+  <meta property="og:url" content="https://www.emnetcm.com/privacy">
+  <meta property="og:locale" content="en_GB">
+  <meta property="og:image" content="https://www.emnetcm.com/assets/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Privacy Policy | EmNet Community Management Limited.">
+  <meta name="twitter:description" content="Learn how EmNet Community Management Limited handles personal data, cookies, and your privacy rights.">
+  <meta name="twitter:image" content="https://www.emnetcm.com/assets/og-image.png">
+  <meta name="twitter:site" content="@EmnetCm">
+  <meta name="twitter:creator" content="@EmnetCm">
+  <link rel="icon" href="assets/favicon.png">
+  <link rel="stylesheet" href="styles/main.css">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "name": "Privacy Policy",
+      "url": "https://www.emnetcm.com/privacy",
+      "publisher": {
+        "@type": "Organization",
+        "name": "EmNet Community Management Limited",
+        "url": "https://www.emnetcm.com/"
+      }
+    }
+  </script>
+</head>
+<body>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="index.html" class="logo-link" aria-label="EmNet home">
+        <img src="assets/logo.png" alt="EmNet logo" class="logo">
+      </a>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+      </button>
+      <nav class="nav" id="primary-nav">
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="services.html">Services</a>
+        <a href="how-we-work.html">How we work</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container section">
+    <h1>Privacy Policy</h1>
+    <p>Last updated: 2 October 2025</p>
+
+    <p>EmNet Community Management Ltd (“EmNet”, “we”, “our”, or “us”) operates this website to provide information about our services. We respect your privacy and are committed to protecting it.</p>
+
+    <h2>Information we collect</h2>
+    <p>This website itself does not actively collect personal information. However, certain information is collected automatically by our hosting provider (GitHub Pages) when you visit the site. This may include your IP address, browser type, and standard log data necessary to deliver the site securely.</p>
+    <p>If you choose to contact us by email or Telegram, we will receive the information you provide (such as your name, email address, Telegram handle, or message content).</p>
+
+    <h2>How we use information</h2>
+    <p>We use any information you provide solely for the purpose of responding to your enquiry or providing the services you request. We do not sell or share your personal data with third parties.</p>
+
+    <h2>Cookies</h2>
+    <p>This site does not set cookies by default. If we introduce analytics or service integrations in the future, we will notify visitors and request consent through a cookie banner.</p>
+
+    <h2>Third-party services</h2>
+    <p>Our site is hosted by GitHub Pages. GitHub may collect limited technical information to operate and secure the service. You can view GitHub’s privacy policy here: <a href="https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement">https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement</a>.</p>
+    <p>If you choose to contact us via Telegram, please note that Telegram’s platform policies apply: <a href="https://telegram.org/privacy">https://telegram.org/privacy</a>.</p>
+
+    <h2>Data retention</h2>
+    <p>We retain contact information only for as long as necessary to provide our services or comply with legal obligations.</p>
+
+    <h2>Your rights</h2>
+    <p>If you are based in the UK or EU, you have rights under data protection law, including the right to access, correct, or request deletion of your personal data. To exercise these rights, please contact us at: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a>.</p>
+
+    <h2>Contact</h2>
+    <p>EmNet Community Management Ltd<br>
+    Company Number: 13716390<br>
+    Registrar of Companies for England and Wales<br>
+    Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a><br>
+    Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></p>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-meta">
+        <small>© <span class="js-current-year"></span> EmNet Community Management Limited</small>
+        <small>Company No. 13716390</small>
+        <small>Registrar of Companies for England and Wales</small>
+        <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
+        <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
+        <small><a href="privacy.html" aria-current="page">Privacy Policy</a></small>
+      </div>
+      <ul class="footer-social" aria-label="Contact and social links">
+        <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
+        <li><a href="https://x.com/EmnetCm" target="_blank" rel="noopener"><img src="assets/xlogo.png" alt="X"></a></li>
+        <li><a href="https://t.me/millieme85" target="_blank" rel="noopener"><img src="assets/tglogo.png" alt="Telegram"></a></li>
+      </ul>
+    </div>
+  </footer>
+  <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
+    <div class="container cookie-banner__inner">
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <button type="button" class="cookie-banner__button js-cookie-accept">Accept</button>
+    </div>
+  </div>
+  <script src="assets/site.js" defer></script>
+  <script>
+    document.querySelectorAll('.js-current-year').forEach(function (el) {
+      el.textContent = new Date().getFullYear();
+    });
+  </script>
+</body>
+</html>

--- a/services.html
+++ b/services.html
@@ -191,6 +191,7 @@
         <small>Registrar of Companies for England and Wales</small>
         <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
         <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
+        <small><a href="privacy.html">Privacy Policy</a></small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
@@ -199,6 +200,12 @@
       </ul>
     </div>
   </footer>
+  <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
+    <div class="container cookie-banner__inner">
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <button type="button" class="cookie-banner__button js-cookie-accept">Accept</button>
+    </div>
+  </div>
   <script src="assets/site.js" defer></script>
   <script>
     document.querySelectorAll('.js-current-year').forEach(function (el) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -5,6 +5,7 @@
 
 :root {
   --site-header-height: 64px;
+  --cookie-banner-height: 0px;
 }
 
 .sr-only {
@@ -37,7 +38,7 @@ body {
   border-bottom: 1px solid #333;
   background: #111;
   position: sticky;
-  top: 0;
+  top: var(--cookie-banner-height, 0px);
   z-index: 10;
 }
 
@@ -803,8 +804,87 @@ body.about-page .hero-logo {
   height: auto;
 }
 
+/* Cookie banner */
+body.cookie-banner-visible {
+  padding-top: var(--cookie-banner-height, 0px);
+}
+
+.cookie-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  width: 100%;
+  background: #111111;
+  color: #ffffff;
+  border-bottom: 1px solid #333333;
+  padding: 18px 0;
+  display: none;
+  z-index: 100;
+}
+
+.cookie-banner.is-visible {
+  display: block;
+}
+
+.cookie-banner__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.cookie-banner__message {
+  margin: 0;
+  flex: 1 1 260px;
+  color: #f0f0f0;
+}
+
+.cookie-banner__message a {
+  color: #ff2ebd;
+  text-decoration: underline;
+}
+
+.cookie-banner__message a:hover,
+.cookie-banner__message a:focus-visible {
+  color: #ff5bd0;
+}
+
+.cookie-banner__button {
+  flex: 0 0 auto;
+  padding: 10px 24px;
+  border: none;
+  border-radius: 999px;
+  background: #ff2ebd;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.cookie-banner__button:hover,
+.cookie-banner__button:focus-visible {
+  background: #ff5bd0;
+  outline: none;
+}
+
 /* Mobile tweaks */
 @media (max-width: 640px) {
+  .cookie-banner {
+    padding: 16px 0;
+  }
+
+  .cookie-banner__inner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .cookie-banner__message {
+    flex-basis: auto;
+  }
+
   .header-inner {
     flex-wrap: wrap;
     height: auto;


### PR DESCRIPTION
## Summary
- add a dedicated privacy.html page that mirrors site chrome and publishes the full privacy policy copy
- implement a reusable cookie consent banner, styling, and persistence so it appears across pages until accepted and now sits at the top of the viewport without covering the header
- link the privacy policy from every footer and banner for easy access

## Testing
- Tests not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de63aa42688322aa58c89b535a6d34