### PR TITLE
Add contact page and enhance cookie banner

### DIFF
--- a/about.html
+++ b/about.html
@@ -65,7 +65,7 @@
         <a href="about.html" aria-current="page">About</a>
         <a href="services.html">Services</a>
         <a href="how-we-work.html">How we work</a>
-        <a href="index.html#contact">Contact</a>
+        <a href="contact.html">Contact</a>
       </nav>
     </div>
   </header>
@@ -78,7 +78,7 @@
           <div class="container">
             <h1>About Us</h1>
             <p>Building sustainable, high-trust communities for projects that value long-term impact.</p>
-            <a class="btn" href="index.html#contact">Contact us</a>
+            <a class="btn" href="contact.html">Contact us</a>
           </div>
         </div>
       </div>
@@ -120,7 +120,10 @@
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
       <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
-      <button type="button" class="cookie-banner__button js-cookie-accept">Accept</button>
+      <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
+        <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
+        <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>
+      </div>
     </div>
   </div>
   <script src="assets/site.js" defer></script>

--- a/assets/site.js
+++ b/assets/site.js
@@ -92,6 +92,82 @@
 })();
 
 (function () {
+  const form = document.querySelector('.js-contact-form');
+  if (!form) {
+    return;
+  }
+
+  const confirmation = form.querySelector('.js-contact-confirmation');
+  const messageInput = form.querySelector('textarea[name="message"]');
+  const subjectSelect = form.querySelector('select[name="subject"]');
+
+  form.addEventListener('input', (event) => {
+    if (confirmation && !confirmation.hidden) {
+      confirmation.hidden = true;
+    }
+
+    if (event.target === messageInput && messageInput) {
+      messageInput.setCustomValidity('');
+    }
+  });
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    if (messageInput) {
+      messageInput.setCustomValidity('');
+    }
+
+    if (typeof form.reportValidity === 'function' && !form.reportValidity()) {
+      return;
+    }
+
+    const formData = new FormData(form);
+    const getValue = (name) => {
+      const value = formData.get(name);
+      return typeof value === 'string' ? value.trim() : '';
+    };
+
+    const message = getValue('message');
+    if (messageInput && message.length < 10) {
+      messageInput.setCustomValidity('Message must be at least 10 characters long.');
+      messageInput.reportValidity();
+      return;
+    }
+
+    const name = getValue('name') || 'N/A';
+    const email = getValue('email') || 'N/A';
+    const subject = getValue('subject') || 'General enquiry';
+
+    const emailSubject = `Website contact: ${subject}`;
+    const bodyLines = [
+      `Name: ${name}`,
+      `Email: ${email}`,
+      `Subject: ${subject}`,
+      '',
+      message,
+    ];
+
+    const mailtoLink = `mailto:emnet@emnetcm.com?subject=${encodeURIComponent(emailSubject)}&body=${encodeURIComponent(bodyLines.join('\n'))}`;
+
+    try {
+      window.location.href = mailtoLink;
+    } catch (error) {
+      // Ignore navigation errors.
+    }
+
+    if (confirmation) {
+      confirmation.hidden = false;
+    }
+
+    form.reset();
+    if (subjectSelect) {
+      subjectSelect.value = 'General enquiry';
+    }
+  });
+})();
+
+(function () {
   if (!('IntersectionObserver' in window)) {
     return;
   }

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Contact EmNet | EmNet Community Management Limited.</title>
+  <meta name="description" content="Get in touch with EmNet Community Management Limited. Reach us on Twitter, email, or send a message through our contact form.">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self' mailto:; frame-ancestors 'none'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-DGqo2Kb4k72J1TxKVIARDY7Dyoc1OXsNQ22Wn1p5oMU='; style-src 'self'">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
+  <meta name="keywords" content="contact EmNet, Web3 community management contact, EmNet email, EmNet Twitter">
+  <meta name="author" content="EmNet Community Management Limited">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://www.emnetcm.com/contact">
+  <meta property="og:title" content="Contact EmNet | EmNet Community Management Limited.">
+  <meta property="og:description" content="Speak to the EmNet team about community operations, automation, and support.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="EmNet Community Management Limited">
+  <meta property="og:url" content="https://www.emnetcm.com/contact">
+  <meta property="og:locale" content="en_GB">
+  <meta property="og:image" content="https://www.emnetcm.com/assets/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Contact EmNet | EmNet Community Management Limited.">
+  <meta name="twitter:description" content="Speak to the EmNet team about community operations, automation, and support.">
+  <meta name="twitter:image" content="https://www.emnetcm.com/assets/og-image.png">
+  <meta name="twitter:site" content="@EmnetCm">
+  <meta name="twitter:creator" content="@EmnetCm">
+  <link rel="icon" href="assets/favicon.png">
+  <link rel="stylesheet" href="styles/main.css">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ContactPage",
+      "name": "Contact EmNet Community Management Limited",
+      "url": "https://www.emnetcm.com/contact",
+      "about": {
+        "@type": "Organization",
+        "name": "EmNet Community Management Limited",
+        "email": "emnet@emnetcm.com",
+        "sameAs": [
+          "https://x.com/EmilyConway85",
+          "https://t.me/millieme85"
+        ]
+      },
+      "contactPoint": {
+        "@type": "ContactPoint",
+        "contactType": "Customer Support",
+        "email": "emnet@emnetcm.com",
+        "availableLanguage": ["English"]
+      }
+    }
+  </script>
+</head>
+<body class="contact-page">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="index.html" class="logo-link" aria-label="EmNet home">
+        <img src="assets/logo.png" alt="EmNet logo" class="logo" width="1024" height="1024" decoding="async">
+      </a>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+      </button>
+      <nav class="nav" id="primary-nav">
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="services.html">Services</a>
+        <a href="how-we-work.html">How we work</a>
+        <a href="contact.html" aria-current="page">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero hero-contact">
+      <div class="container hero-contact__inner">
+        <h1>Contact EmNet</h1>
+        <p>Reach out for community operations, automation, or support. We respond to every enquiry.</p>
+        <div class="contact-hero-actions">
+          <a class="btn" href="mailto:emnet@emnetcm.com">Email EmNet</a>
+          <a class="btn" href="https://x.com/EmilyConway85" target="_blank" rel="noopener">Twitter: @EmilyConway85</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="container section contact-section">
+      <div class="contact-layout">
+        <div class="contact-details" aria-labelledby="contact-details-title">
+          <h2 id="contact-details-title">Direct contact</h2>
+          <p>Prefer a direct channel? Use any of the details below and we&rsquo;ll reply promptly.</p>
+          <ul class="contact-details__list">
+            <li>
+              <span class="contact-details__label">Email</span>
+              <a href="mailto:emnet@emnetcm.com">emnet@emnetcm.com</a>
+            </li>
+            <li>
+              <span class="contact-details__label">Twitter</span>
+              <a href="https://x.com/EmilyConway85" target="_blank" rel="noopener">@EmilyConway85</a>
+            </li>
+            <li>
+              <span class="contact-details__label">Telegram</span>
+              <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a>
+            </li>
+          </ul>
+          <p class="contact-details__note">Business hours: Monday to Friday, 9am – 6pm (UTC). We aim to reply within one working day.</p>
+        </div>
+
+        <form class="contact-form js-contact-form" action="mailto:emnet@emnetcm.com" method="post" enctype="text/plain" novalidate>
+          <h2>Send us a message</h2>
+          <p class="contact-form__intro">Complete the form and we&rsquo;ll get back to you shortly.</p>
+          <div class="contact-form__field">
+            <label for="contact-name">Name</label>
+            <input id="contact-name" name="name" type="text" autocomplete="name" required>
+          </div>
+          <div class="contact-form__field">
+            <label for="contact-email">Email address</label>
+            <input id="contact-email" name="email" type="email" autocomplete="email" required>
+          </div>
+          <div class="contact-form__field">
+            <label for="contact-subject">Subject</label>
+            <select id="contact-subject" name="subject" required>
+              <option value="General enquiry" selected>General enquiry</option>
+              <option value="Service request">Service request</option>
+              <option value="Support">Support</option>
+              <option value="Other">Other</option>
+            </select>
+          </div>
+          <div class="contact-form__field">
+            <label for="contact-message">Message</label>
+            <textarea id="contact-message" name="message" rows="6" required></textarea>
+          </div>
+          <div class="contact-form__actions">
+            <button type="submit" class="contact-form__submit">Send message</button>
+          </div>
+          <p class="contact-form__privacy">We only use your details to respond to your enquiry. Read our <a href="privacy.html">Privacy Policy</a>.</p>
+          <p class="contact-form__confirmation js-contact-confirmation" hidden role="status" aria-live="polite">Thank you, we&rsquo;ll be in touch shortly.</p>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-meta">
+        <small>© <span class="js-current-year"></span> EmNet Community Management Limited</small>
+        <small>Company No. 13716390</small>
+        <small>Registrar of Companies for England and Wales</small>
+        <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
+        <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
+        <small><a href="privacy.html">Privacy Policy</a></small>
+      </div>
+      <ul class="footer-social" aria-label="Contact and social links">
+        <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
+        <li><a href="https://x.com/EmnetCm" target="_blank" rel="noopener"><img src="assets/xlogo.png" alt="X" width="166" height="137" loading="lazy" decoding="async"></a></li>
+        <li><a href="https://t.me/millieme85" target="_blank" rel="noopener"><img src="assets/tglogo.png" alt="Telegram" width="132" height="132" loading="lazy" decoding="async"></a></li>
+      </ul>
+    </div>
+  </footer>
+  <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
+    <div class="container cookie-banner__inner">
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
+        <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
+        <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>
+      </div>
+    </div>
+  </div>
+  <script src="assets/site.js" defer></script>
+</body>
+</html>

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -87,7 +87,7 @@
         <a href="about.html">About</a>
         <a href="services.html">Services</a>
         <a href="how-we-work.html" aria-current="page">How we work</a>
-        <a href="#contact">Contact</a>
+        <a href="contact.html">Contact</a>
       </nav>
     </div>
   </header>
@@ -243,7 +243,10 @@
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
       <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
-      <button type="button" class="cookie-banner__button js-cookie-accept">Accept</button>
+      <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
+        <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
+        <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>
+      </div>
     </div>
   </div>
   <script src="assets/site.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
         <a href="about.html">About</a>
         <a href="services.html">Services</a>
         <a href="how-we-work.html">How we work</a>
-        <a href="#contact">Contact</a>
+        <a href="contact.html">Contact</a>
       </nav>
     </div>
   </header>
@@ -76,7 +76,7 @@
         <img src="assets/logo.png" alt="EmNet logo" class="hero-logo" width="1024" height="1024" decoding="async">
         <h1>EmNet Community Management Ltd</h1>
         <p>Operational excellence for social platforms. Telegram, and on-chain community tooling.</p>
-        <a class="btn" href="#contact">Get in touch</a>
+        <a class="btn" href="contact.html">Get in touch</a>
       </div>
     </section>
 
@@ -162,7 +162,10 @@
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
       <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
-      <button type="button" class="cookie-banner__button js-cookie-accept">Accept</button>
+      <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
+        <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
+        <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>
+      </div>
     </div>
   </div>
   <script src="assets/site.js" defer></script>

--- a/privacy.html
+++ b/privacy.html
@@ -57,7 +57,7 @@
         <a href="about.html">About</a>
         <a href="services.html">Services</a>
         <a href="how-we-work.html">How we work</a>
-        <a href="index.html#contact">Contact</a>
+        <a href="contact.html">Contact</a>
       </nav>
     </div>
   </header>
@@ -116,7 +116,10 @@
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
       <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
-      <button type="button" class="cookie-banner__button js-cookie-accept">Accept</button>
+      <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
+        <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
+        <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>
+      </div>
     </div>
   </div>
   <script src="assets/site.js" defer></script>

--- a/services.html
+++ b/services.html
@@ -71,7 +71,7 @@
         <a href="about.html">About</a>
         <a href="services.html" aria-current="page">Services</a>
         <a href="how-we-work.html">How we work</a>
-        <a href="index.html#contact">Contact</a>
+        <a href="contact.html">Contact</a>
       </nav>
     </div>
   </header>
@@ -205,7 +205,10 @@
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
       <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
-      <button type="button" class="cookie-banner__button js-cookie-accept">Accept</button>
+      <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
+        <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
+        <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>
+      </div>
     </div>
   </div>
   <script src="assets/site.js" defer></script>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -13,6 +13,9 @@
     <loc>https://www.emnetcm.com/how-we-work.html</loc>
   </url>
   <url>
+    <loc>https://www.emnetcm.com/contact.html</loc>
+  </url>
+  <url>
     <loc>https://www.emnetcm.com/privacy.html</loc>
   </url>
 </urlset>

--- a/styles/main.css
+++ b/styles/main.css
@@ -595,6 +595,198 @@ body.about-page .hero-logo {
   max-width: 520px;
 }
 
+/* Contact page */
+.hero-contact {
+  background: linear-gradient(160deg, #111111 0%, #050505 55%, #101010 100%);
+}
+
+.hero-contact__inner {
+  display: grid;
+  gap: 16px;
+  justify-items: center;
+  text-align: center;
+}
+
+.hero-contact__inner h1 {
+  font-size: clamp(40px, 6vw, 64px);
+  margin: 0;
+}
+
+.hero-contact__inner p {
+  max-width: 640px;
+  margin: 0 auto;
+  color: #e6e6e6;
+  font-size: 1.125rem;
+}
+
+.contact-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+.contact-section {
+  padding: clamp(56px, 7vw, 96px) 0;
+}
+
+.contact-layout {
+  display: grid;
+  gap: clamp(32px, 5vw, 64px);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.contact-details {
+  background: linear-gradient(160deg, rgba(255, 46, 189, 0.12) 0%, rgba(14, 14, 14, 0.95) 100%);
+  border: 1px solid rgba(255, 46, 189, 0.24);
+  border-radius: 24px;
+  padding: clamp(24px, 4vw, 36px);
+  display: grid;
+  gap: 18px;
+}
+
+.contact-details__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.contact-details__label {
+  display: block;
+  font-weight: 600;
+  color: #ff2ebd;
+  margin-bottom: 4px;
+  letter-spacing: 0.01em;
+}
+
+.contact-details a {
+  color: #ffffff;
+  text-decoration: none;
+  word-break: break-word;
+}
+
+.contact-details a:hover,
+.contact-details a:focus-visible {
+  color: #ff5bd0;
+  text-decoration: underline;
+}
+
+.contact-details__note {
+  margin: 0;
+  color: #bbbbbb;
+  font-size: 0.95rem;
+}
+
+.contact-form {
+  background: rgba(12, 12, 12, 0.96);
+  border: 1px solid rgba(255, 46, 189, 0.18);
+  border-radius: 24px;
+  padding: clamp(24px, 4vw, 36px);
+  display: grid;
+  gap: 18px;
+}
+
+.contact-form__intro {
+  margin: 0;
+  color: #cfcfcf;
+}
+
+.contact-form__field {
+  display: grid;
+  gap: 8px;
+}
+
+.contact-form label {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.contact-form input,
+.contact-form select,
+.contact-form textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #2a2a2a;
+  background: #050505;
+  color: #ffffff;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-form input:focus-visible,
+.contact-form select:focus-visible,
+.contact-form textarea:focus-visible {
+  border-color: #ff2ebd;
+  box-shadow: 0 0 0 3px rgba(255, 46, 189, 0.25);
+  outline: none;
+}
+
+.contact-form select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, #ff2ebd 50%), linear-gradient(135deg, #ff2ebd 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(50% - 2px), calc(100% - 12px) calc(50% - 2px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+  padding-right: 40px;
+}
+
+.contact-form textarea {
+  resize: vertical;
+  min-height: 180px;
+}
+
+.contact-form__actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.contact-form__submit {
+  padding: 12px 28px;
+  border-radius: 999px;
+  border: none;
+  background: #ff2ebd;
+  color: #000000;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.contact-form__submit:hover,
+.contact-form__submit:focus-visible {
+  background: #ff5bd0;
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.contact-form__privacy {
+  margin: 0;
+  color: #bdbdbd;
+  font-size: 0.95rem;
+}
+
+.contact-form__privacy a {
+  color: #ff2ebd;
+}
+
+.contact-form__privacy a:hover,
+.contact-form__privacy a:focus-visible {
+  color: #ff5bd0;
+}
+
+.contact-form__confirmation {
+  margin: 0;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: rgba(52, 168, 83, 0.16);
+  border: 1px solid rgba(52, 168, 83, 0.35);
+  color: #c6f9d7;
+  font-weight: 600;
+}
+
 .individual-services ul {
   list-style: none;
   margin: 24px 0 0;
@@ -835,6 +1027,13 @@ body.cookie-banner-visible {
   flex-wrap: wrap;
 }
 
+.cookie-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
 .cookie-banner__message {
   margin: 0;
   flex: 1 1 260px;
@@ -853,20 +1052,46 @@ body.cookie-banner-visible {
 
 .cookie-banner__button {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 10px 24px;
-  border: none;
+  border: 1px solid transparent;
   border-radius: 999px;
-  background: #ff2ebd;
-  color: #ffffff;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  text-decoration: none;
 }
 
-.cookie-banner__button:hover,
 .cookie-banner__button:focus-visible {
+  outline: 2px solid #ff5bd0;
+  outline-offset: 3px;
+}
+
+.cookie-banner__button--primary {
+  background: #ff2ebd;
+  color: #ffffff;
+  border-color: #ff2ebd;
+}
+
+.cookie-banner__button--primary:hover,
+.cookie-banner__button--primary:focus-visible {
   background: #ff5bd0;
-  outline: none;
+  color: #000000;
+}
+
+.cookie-banner__button--secondary {
+  background: transparent;
+  color: #ff2ebd;
+  border-color: #ff2ebd;
+}
+
+.cookie-banner__button--secondary:hover,
+.cookie-banner__button--secondary:focus-visible {
+  background: rgba(255, 46, 189, 0.15);
+  color: #ff5bd0;
+  border-color: #ff5bd0;
 }
 
 /* Mobile tweaks */
@@ -927,6 +1152,22 @@ body.cookie-banner-visible {
 
   .hero h1 {
     font-size: 32px;
+  }
+
+  .contact-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-contact__inner {
+    justify-items: stretch;
+  }
+
+  .contact-form__actions {
+    justify-content: stretch;
+  }
+
+  .contact-form__submit {
+    width: 100%;
   }
 
   .workflow-section {


### PR DESCRIPTION
## Summary
- add a dedicated contact page with direct contact information and a validated enquiry form
- update site navigation and sitemap entries to link to the new contact page
- add a decline option to the cookie banner with refreshed button styling

## Testing
- npm install *(fails: 403 Forbidden when fetching @lhci/cli)*

------
https://chatgpt.com/codex/tasks/task_e_68de714a78208322b935b05d7ba5c1df