### PR TITLE
Adjust home hero spacing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -192,7 +192,7 @@ body {
 }
 
 .hero-home {
-  padding: clamp(16px, 4vw, 32px) 0 0;
+  padding: clamp(64px, 12vw, 120px) 0 0;
 }
 
 .hero-home .hero-banner-content .container {


### PR DESCRIPTION
## Summary
- increase the top padding of the home page hero to create more space between the navigation bar and hero logo

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68dedd5c726c832294153001aa71b9f2