### PR TITLE
Fix hero banner stacking to restore Home image

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -168,7 +168,7 @@ body {
   position: absolute;
   inset: 0;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0.45) 0%, rgba(0, 0, 0, 0.65) 100%);
-  z-index: 0;
+  z-index: 1;
 }
 
 .hero-banner-content {
@@ -179,7 +179,7 @@ body {
   text-align: center;
   padding: clamp(28px, 6vw, 48px) 20px;
   position: absolute;
-  z-index: 1;
+  z-index: 2;
 }
 
 .hero-banner-content .container {
@@ -192,7 +192,28 @@ body {
 }
 
 .hero-home {
-  padding: clamp(64px, 12vw, 120px) 0 0;
+  --hero-home-offset: clamp(64px, 12vw, 120px);
+  padding: var(--hero-home-offset) 0 0;
+}
+
+.hero-home .hero-banner {
+  min-height: clamp(280px, 45vw, 520px);
+  isolation: isolate;
+}
+
+.hero-home .hero-banner::after {
+  top: calc(-1 * var(--hero-home-offset));
+  bottom: 0;
+}
+
+.hero-home .hero-banner-image {
+  position: absolute;
+  top: calc(-1 * var(--hero-home-offset));
+  left: 0;
+  width: 100%;
+  height: calc(clamp(280px, 45vw, 520px) + var(--hero-home-offset));
+  object-fit: cover;
+  z-index: 0;
 }
 
 .hero-home .hero-banner-content .container {


### PR DESCRIPTION
## Summary
- adjust the hero banner stacking order so Home.jpg renders beneath the gradient while content stays above
- isolate the home hero banner so the stretched image remains visible without affecting logo spacing

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dee876c51c8322ae2695acd42d2ba5