### PR TITLE
Align contact form with FormSubmit AJAX endpoint

### DIFF
--- a/assets/site.js
+++ b/assets/site.js
@@ -93,7 +93,7 @@
 
 (function () {
   const form = document.querySelector('.js-contact-form');
-  if (!form) {
+  if (!form || typeof window.fetch !== 'function') {
     return;
   }
 
@@ -170,18 +170,28 @@
     const email = getValue('email') || 'N/A';
     const subject = getValue('subject') || 'General enquiry';
 
+    const endpoint = form.dataset.formsubmitEndpoint || form.action;
+
     try {
       formData.set('name', name);
       formData.set('email', email);
       formData.set('subject', subject);
       formData.set('message', message);
 
-      const response = await fetch(form.action, {
+      const payload = {};
+      formData.forEach((value, key) => {
+        if (typeof value === 'string') {
+          payload[key] = value;
+        }
+      });
+
+      const response = await fetch(endpoint, {
         method: form.method || 'POST',
         headers: {
           Accept: 'application/json',
+          'Content-Type': 'application/json',
         },
-        body: formData,
+        body: JSON.stringify(payload),
       });
 
       if (!response.ok) {

--- a/contact.html
+++ b/contact.html
@@ -106,7 +106,7 @@
           <p class="contact-details__note">Business hours: Monday to Friday, 9am – 6pm (UTC). We aim to reply within one working day.</p>
         </div>
 
-        <form class="contact-form js-contact-form" id="contact-form" action="https://formsubmit.co/emnet@emnetcm.com" method="POST" novalidate>
+        <form class="contact-form js-contact-form" id="contact-form" action="https://formsubmit.co/emnet@emnetcm.com" method="POST" novalidate data-formsubmit-endpoint="https://formsubmit.co/ajax/emnet@emnetcm.com">
           <h2>Send us a message</h2>
           <p class="contact-form__intro">Complete the form and we&rsquo;ll get back to you shortly.</p>
           <div class="contact-form__field">
@@ -136,6 +136,7 @@
           <input type="hidden" name="_subject" value="[EmNet Site] New enquiry">
           <input type="hidden" name="_template" value="table">
           <input type="hidden" name="_captcha" value="false">
+          <input type="hidden" name="_next" value="https://www.emnetcm.com/contact?submitted=true">
           <input type="hidden" name="_honey" tabindex="-1" autocomplete="off" class="contact-form__honeypot" aria-hidden="true">
           <p class="contact-form__privacy">We only use your details to respond to your enquiry. Read our <a href="privacy.html">Privacy Policy</a>.</p>
           <p class="contact-form__error js-contact-error" hidden role="alert" aria-live="assertive">We couldn&rsquo;t send your message just now. Please try again or email <a href="mailto:emnet@emnetcm.com">emnet@emnetcm.com</a>.</p>


### PR DESCRIPTION
## Summary
- configure the contact form with FormSubmit's AJAX endpoint while keeping the existing non-JavaScript fallback
- include the recommended redirect parameter so non-JavaScript submissions return to the contact page
- update the client-side submission script to send a JSON payload to FormSubmit and handle responses

## Testing
- Not run (network restricted environment)


------
https://chatgpt.com/codex/tasks/task_e_68deebceada08322b62edf619161dd42