### PR TITLE
Allow Formsubmit endpoint in contact CSP

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Contact EmNet | EmNet Community Management Limited.</title>
   <meta name="description" content="Community operations for blockchain communities across Algorand and beyond, delivering Telegram bots, automation, and analytics that keep ecosystems thriving.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self' https://formsubmit.co; frame-ancestors 'none'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-DGqo2Kb4k72J1TxKVIARDY7Dyoc1OXsNQ22Wn1p5oMU='; style-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self' https://formsubmit.co; font-src 'self'; form-action 'self' https://formsubmit.co; frame-ancestors 'none'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-DGqo2Kb4k72J1TxKVIARDY7Dyoc1OXsNQ22Wn1p5oMU='; style-src 'self'">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="keywords" content="contact EmNet, Web3 community management contact, EmNet email, EmNet Twitter">
   <meta name="author" content="EmNet Community Management Limited">


### PR DESCRIPTION
## Summary
- allow the Formsubmit AJAX endpoint in the contact page CSP connect-src directive
- verified other pages do not reuse the same CSP snippet and therefore do not need changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def00c7a448322981be4c87c33e191