### PR TITLE
Improve CSP notes and add frame busting guard

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>About EmNet | EmNet Community Management Limited.</title>
   <meta name="description" content="Community operations for blockchain communities across Algorand and beyond, delivering Telegram bots, automation, and analytics that keep ecosystems thriving.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-vppc3mZDtL+b0+YhvbsMUVJzF81gyG4bC8e4g16+HdQ='; style-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-vppc3mZDtL+b0+YhvbsMUVJzF81gyG4bC8e4g16+HdQ='; style-src 'self'">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="keywords" content="EmNet team, Web3 community experts, crypto community strategy, community operations philosophy, EmNet founder">
   <meta name="author" content="EmNet Community Management Limited">

--- a/assets/site.js
+++ b/assets/site.js
@@ -1,3 +1,7 @@
+if (window.top !== window.self) {
+  window.top.location = window.location.href;
+}
+
 (function () {
   const navToggle = document.querySelector('.nav-toggle');
   const nav = document.getElementById('primary-nav');

--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Contact EmNet | EmNet Community Management Limited.</title>
   <meta name="description" content="Community operations for blockchain communities across Algorand and beyond, delivering Telegram bots, automation, and analytics that keep ecosystems thriving.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self' https://formsubmit.co; font-src 'self'; form-action 'self' https://formsubmit.co; frame-ancestors 'none'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-DGqo2Kb4k72J1TxKVIARDY7Dyoc1OXsNQ22Wn1p5oMU='; style-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self' https://formsubmit.co; font-src 'self'; form-action 'self' https://formsubmit.co; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-DGqo2Kb4k72J1TxKVIARDY7Dyoc1OXsNQ22Wn1p5oMU='; style-src 'self'">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="keywords" content="contact EmNet, Web3 community management contact, EmNet email, EmNet Twitter">
   <meta name="author" content="EmNet Community Management Limited">

--- a/docs/audit-2025-10-02.md
+++ b/docs/audit-2025-10-02.md
@@ -27,7 +27,7 @@
 
 ## Header & CSP strategy
 - Added `<meta http-equiv="Content-Security-Policy">` to each page because GitHub Pages cannot set response headers.
-- CSP allows `default-src 'self'`, blocks inline scripts except for whitelisted `sha256-…` hashes covering the structured-data block, and disallows frames (`frame-ancestors 'none'`).
+- Browsers ignore `frame-ancestors` directives delivered via `<meta>` tags, so the directive was removed from the CSP and an early guard in `assets/site.js` forces a top-level navigation when the pages are iframed.
 - `meta name="referrer" content="strict-origin-when-cross-origin"` balances analytics with privacy.
 - HSTS, Permissions-Policy, and other response headers remain unavailable without a CDN/reverse proxy; document this limitation in README.md.
 

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>How we work | EmNet Community Management Limited.</title>
   <meta name="description" content="Community operations for blockchain communities across Algorand and beyond, delivering Telegram bots, automation, and analytics that keep ecosystems thriving.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-GHZMDMftCCb4OM8+8VXt4AnyGQX5rcA2hOSWdHm4868='; style-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-GHZMDMftCCb4OM8+8VXt4AnyGQX5rcA2hOSWdHm4868='; style-src 'self'">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="keywords" content="community operations process, Web3 audit framework, AIS method, EmNet workflow, community sustainment plan">
   <meta name="author" content="EmNet Community Management Limited">

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>EmNet Community Management Limited | Community operations for Web3.</title>
   <meta name="description" content="Community operations for blockchain communities across Algorand and beyond, delivering Telegram bots, automation, and analytics that keep ecosystems thriving.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-7lNqz8L1p9lpLgnnfVmxaxmfTuco9nMoCZaK8+mwkqk='; style-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-7lNqz8L1p9lpLgnnfVmxaxmfTuco9nMoCZaK8+mwkqk='; style-src 'self'">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="keywords" content="Web3 community management, Telegram moderation, crypto community automation, custom telegram bots, community analytics">
   <meta name="author" content="EmNet Community Management Limited">

--- a/privacy.html
+++ b/privacy.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Privacy Policy | EmNet Community Management Limited.</title>
   <meta name="description" content="Community operations for blockchain communities across Algorand and beyond, delivering Telegram bots, automation, and analytics that keep ecosystems thriving.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-AVD5NeE0ymlYjq6rp9h3Pv9mRsTRWbP1yb05v7XmWHM='; style-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-AVD5NeE0ymlYjq6rp9h3Pv9mRsTRWbP1yb05v7XmWHM='; style-src 'self'">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="keywords" content="EmNet privacy policy, data protection, cookie consent, EmNet Community Management Limited">
   <meta name="author" content="EmNet Community Management Limited">

--- a/services.html
+++ b/services.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Services | EmNet Community Management Limited.</title>
   <meta name="description" content="Community operations for blockchain communities across Algorand and beyond, delivering Telegram bots, automation, and analytics that keep ecosystems thriving.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-brLEbcggF/KW/cNqwVnx8A5z6Ly3ANeLn3xFtv1bUw8='; style-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-brLEbcggF/KW/cNqwVnx8A5z6Ly3ANeLn3xFtv1bUw8='; style-src 'self'">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="keywords" content="Telegram moderators for hire, Web3 community services, custom telegram bot development, community analytics reporting, AIS framework">
   <meta name="author" content="EmNet Community Management Limited">


### PR DESCRIPTION
## Summary
- remove the ineffective `frame-ancestors 'none'` directive from each page-level CSP meta tag
- add an early frame-busting guard in `assets/site.js` to escape hostile iframes when headers cannot be set
- document the CSP limitation and script-based mitigation in the security audit

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68def100e9408322b36126f1615cb473