### PR TITLE
Add Algoland campaign progress dashboard

### DIFF
--- a/about.html
+++ b/about.html
@@ -65,6 +65,7 @@
         <a href="about.html" aria-current="page">About</a>
         <a href="services.html">Services</a>
         <a href="how-we-work.html">How we work</a>
+        <a href="algoland.html">Algoland</a>
         <a href="contact.html">Contact</a>
       </nav>
     </div>

--- a/algoland.html
+++ b/algoland.html
@@ -1,0 +1,276 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Algoland progress | EmNet Community Management Limited.</title>
+  <meta name="description" content="Live Algorand Algoland campaign entrants and badge completion counts tracked directly from the blockchain.">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self' https://mainnet-idx.algonode.cloud; font-src 'self'; form-action 'self'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-BkXFec1CkFMHthIcTLpcazC7dGyWpjlM8smsiOdKG4c='; style-src 'self'">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
+  <meta name="keywords" content="Algoland campaign analytics, Algorand community reporting, badge completion tracking">
+  <meta name="author" content="EmNet Community Management Limited">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://www.emnetcm.com/algoland">
+  <meta property="og:title" content="Algoland progress | EmNet Community Management Limited.">
+  <meta property="og:description" content="Track entrants and badge completions for the Algoland retail campaign with live on-chain data.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="EmNet Community Management Limited">
+  <meta property="og:url" content="https://www.emnetcm.com/algoland">
+  <meta property="og:locale" content="en_GB">
+  <meta property="og:image" content="https://www.emnetcm.com/assets/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Algoland progress | EmNet Community Management Limited.">
+  <meta name="twitter:description" content="Track entrants and badge completions for the Algoland retail campaign with live on-chain data.">
+  <meta name="twitter:image" content="https://www.emnetcm.com/assets/og-image.png">
+  <meta name="twitter:site" content="@EmnetCm">
+  <meta name="twitter:creator" content="@EmnetCm">
+  <link rel="icon" href="assets/favicon.png">
+  <link rel="stylesheet" href="styles/main.css">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      "name": "Algoland campaign progress",
+      "creator": {
+        "@type": "Organization",
+        "name": "EmNet Community Management Limited",
+        "url": "https://www.emnetcm.com/"
+      },
+      "license": "https://creativecommons.org/licenses/by/4.0/",
+      "variableMeasured": [
+        "Entrants",
+        "Badge completions",
+        "Conversion rate"
+      ],
+      "measurementTechnique": "Algorand Indexer v2",
+      "spatialCoverage": {
+        "@type": "Place",
+        "name": "Algorand mainnet"
+      },
+      "temporalCoverage": "2024",
+      "url": "https://www.emnetcm.com/algoland",
+      "distribution": {
+        "@type": "DataDownload",
+        "encodingFormat": "application/json",
+        "contentUrl": "https://www.emnetcm.com/algoland"
+      }
+    }
+  </script>
+</head>
+<body class="algoland-page">
+  <header class="site-header">
+    <div class="container header-inner">
+      <a href="index.html" class="logo-link" aria-label="EmNet home">
+        <img src="assets/logo.png" alt="EmNet logo" class="logo" width="1024" height="1024" decoding="async">
+      </a>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+      </button>
+      <nav class="nav" id="primary-nav">
+        <a href="index.html">Home</a>
+        <a href="about.html">About</a>
+        <a href="services.html">Services</a>
+        <a href="how-we-work.html">How we work</a>
+        <a href="algoland.html" aria-current="page">Algoland</a>
+        <a href="contact.html">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main data-algoland-root data-indexer-provider="https://mainnet-idx.algonode.cloud">
+    <section class="container section algoland-hero">
+      <h1>Algoland progress</h1>
+      <p class="section-lede">Live on chain counts of challenge entrants and badge completions.</p>
+      <p>The Algoland retail campaign spans 13 weekly challenges. This page summarises wallet opt-ins to the campaign application and badge completions distributed by approved organisers.</p>
+    </section>
+
+    <section class="container section algoland-summary" aria-live="polite">
+      <div class="summary-grid">
+        <article class="summary-card" role="listitem">
+          <h2>Entrants</h2>
+          <p class="summary-count" data-summary="entrants" title="Wallets opted in to application 3215540125.">—</p>
+          <p class="summary-meta">App 3215540125</p>
+        </article>
+        <article class="summary-card" role="listitem">
+          <h2>Week 1 completed</h2>
+          <p class="summary-count" data-summary="week-1" title="Wallets that received the week’s badge from the official distributor.">—</p>
+          <p class="summary-meta">ASA 3215542831</p>
+        </article>
+        <article class="summary-card" role="listitem">
+          <h2>Week 2 completed</h2>
+          <p class="summary-count" data-summary="week-2" title="Wallets that received the week’s badge from the official distributor.">—</p>
+          <p class="summary-meta">ASA 3215542840</p>
+        </article>
+        <article class="summary-card" role="listitem">
+          <h2>Overall completed</h2>
+          <p class="summary-count" data-summary="overall">—</p>
+          <p class="summary-meta">Live weeks only</p>
+        </article>
+      </div>
+      <p class="last-updated" data-algoland-updated aria-live="polite"></p>
+    </section>
+
+    <section class="container section algoland-table-section">
+      <div class="algoland-alerts" role="status" aria-live="polite" data-algoland-alerts></div>
+      <div class="table-wrapper">
+        <table class="data-table algoland-table" data-algoland-table>
+          <caption>Weekly Algoland challenge performance</caption>
+          <thead>
+            <tr>
+              <th scope="col">Week</th>
+              <th scope="col">Badge ASA</th>
+              <th scope="col">Distributor (short)</th>
+              <th scope="col">Entrants</th>
+              <th scope="col">Completed</th>
+              <th scope="col">Conversion</th>
+              <th scope="col">Explorer links</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr data-week="1">
+              <th scope="row">Week 1</th>
+              <td data-col="badge">3215542831</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed" title="Wallets that received the week’s badge from the official distributor.">—</td>
+              <td data-col="conversion">—</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="2">
+              <th scope="row">Week 2</th>
+              <td data-col="badge">3215542840</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed" title="Wallets that received the week’s badge from the official distributor.">—</td>
+              <td data-col="conversion">—</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="3">
+              <th scope="row">Week 3</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="4">
+              <th scope="row">Week 4</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="5">
+              <th scope="row">Week 5</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="6">
+              <th scope="row">Week 6</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="7">
+              <th scope="row">Week 7</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="8">
+              <th scope="row">Week 8</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="9">
+              <th scope="row">Week 9</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="10">
+              <th scope="row">Week 10</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="11">
+              <th scope="row">Week 11</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="12">
+              <th scope="row">Week 12</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+            <tr data-week="13">
+              <th scope="row">Week 13</th>
+              <td data-col="badge">Coming soon</td>
+              <td data-col="distributor" data-distributor-index="0"></td>
+              <td data-col="entrants" title="Wallets opted in to application 3215540125.">—</td>
+              <td data-col="completed">N/A</td>
+              <td data-col="conversion">N/A</td>
+              <td data-col="links"></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-inner">
+      <div class="footer-meta">
+        <small>© <span class="js-current-year"></span> EmNet Community Management Limited, Company No. 13716390, Registrar of Companies for England and Wales</small>
+        <small>Email: <a href="mailto:Emnet@emnetcm.com">Emnet@emnetcm.com</a></small>
+        <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
+        <small><a href="privacy.html">Privacy Policy</a></small>
+        <small>Proudly aligned with the Algorand ecosystem.</small>
+      </div>
+      <ul class="footer-social" aria-label="Contact and social links">
+        <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
+        <li><a href="https://x.com/EmnetCm" target="_blank" rel="noopener"><img src="assets/xlogo.png" alt="X" width="166" height="137" loading="lazy" decoding="async"></a></li>
+        <li><a href="https://t.me/millieme85" target="_blank" rel="noopener"><img src="assets/tglogo.png" alt="Telegram" width="132" height="132" loading="lazy" decoding="async"></a></li>
+      </ul>
+    </div>
+  </footer>
+
+  <script src="assets/site.js" defer></script>
+  <script src="assets/algoland.js" defer></script>
+</body>
+</html>

--- a/assets/algoland.js
+++ b/assets/algoland.js
@@ -1,0 +1,700 @@
+(function () {
+  const root = document.querySelector('[data-algoland-root]');
+  if (!root || typeof window.fetch !== 'function') {
+    return;
+  }
+
+  const APP_ID = 3215540125;
+  const CAMPAIGN_NAME = 'Algoland retail campaign';
+  const KNOWN_ORGANISER_PREFIX = 'LANDBACKOF354GJUI4HMC6G2G3EGHEXDUZ4YEDDTJSSTIAZ3X4M5TLX3BI';
+  const DEFAULT_DISTRIBUTOR = 'HHADCZKQV24QDCBER5GTOH7BOLF4ZQ6WICNHAA3GZUECIMJXIIMYBIWEZM';
+  const SNAPSHOT_KEY = 'emnet.algoland.snapshot.v1';
+  const CACHE_MS = 10 * 60 * 1000;
+  const REFRESH_INTERVAL_MS = 10 * 60 * 1000;
+  const MAX_RETRIES = 4;
+  const RETRY_BASE_DELAY_MS = 600;
+  const providerBase = root.dataset.indexerProvider || window.EMNET_INDEXER_PROVIDER || 'https://mainnet-idx.algonode.cloud';
+  const numberFormatter = new Intl.NumberFormat('en-GB');
+  const percentFormatter = new Intl.NumberFormat('en-GB', {
+    style: 'percent',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  const weeksConfig = [
+    { week: 1, assetId: '3215542831', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 2, assetId: '3215542840', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 3, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 4, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 5, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 6, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 7, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 8, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 9, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 10, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 11, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 12, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+    { week: 13, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
+  ];
+
+  const summaryElements = {
+    entrants: root.querySelector('[data-summary="entrants"]'),
+    week1: root.querySelector('[data-summary="week-1"]'),
+    week2: root.querySelector('[data-summary="week-2"]'),
+    overall: root.querySelector('[data-summary="overall"]'),
+  };
+  const alertsContainer = root.querySelector('[data-algoland-alerts]');
+  const table = root.querySelector('[data-algoland-table]');
+  const updatedElement = root.querySelector('[data-algoland-updated]');
+  const appExplorerUrl = `https://allo.info/application/${APP_ID}`;
+
+  let lastSnapshot = loadSnapshot();
+  let isRefreshing = false;
+
+  console.info('[Algoland] Initialised Algoland dashboard', { provider: providerBase });
+
+  initialiseStaticTable();
+
+  if (lastSnapshot) {
+    renderSnapshot(lastSnapshot, { fromCache: true, warnings: [] });
+  }
+
+  refreshData({ reason: 'initial load' });
+  window.setInterval(() => {
+    refreshData({ reason: 'scheduled interval' });
+  }, REFRESH_INTERVAL_MS);
+
+  function initialiseStaticTable() {
+    if (!table) {
+      return;
+    }
+
+    weeksConfig.forEach((config) => {
+      const row = table.querySelector(`tr[data-week="${config.week}"]`);
+      if (!row) {
+        return;
+      }
+
+      const badgeCell = row.querySelector('[data-col="badge"]');
+      if (badgeCell) {
+        if (config.assetId) {
+          badgeCell.textContent = config.assetId;
+          badgeCell.classList.remove('na-value');
+        } else {
+          badgeCell.textContent = 'Coming soon';
+          badgeCell.classList.add('na-value');
+        }
+      }
+
+      const distributorCell = row.querySelector('[data-col="distributor"]');
+      if (distributorCell) {
+        distributorCell.textContent = '';
+        config.distributors.forEach((address) => {
+          const pill = document.createElement('span');
+          pill.className = 'address-pill';
+          pill.textContent = shortenAddress(address);
+          pill.title = address;
+          distributorCell.appendChild(pill);
+        });
+      }
+
+      const linksCell = row.querySelector('[data-col="links"]');
+      if (linksCell) {
+        linksCell.textContent = '';
+        linksCell.appendChild(createExplorerLink(appExplorerUrl, 'App'));
+        if (config.assetId) {
+          linksCell.appendChild(createExplorerLink(`https://allo.info/asset/${config.assetId}`, 'Badge'));
+        }
+        config.distributors.forEach((address, index) => {
+          const label = config.distributors.length > 1 ? `Distributor ${index + 1}` : 'Distributor';
+          linksCell.appendChild(createExplorerLink(`https://allo.info/address/${address}`, label));
+        });
+      }
+
+      const completedCell = row.querySelector('[data-col="completed"]');
+      const conversionCell = row.querySelector('[data-col="conversion"]');
+      if (!config.assetId) {
+        if (completedCell) {
+          completedCell.textContent = 'N/A';
+          completedCell.classList.add('na-value');
+        }
+        if (conversionCell) {
+          conversionCell.textContent = 'N/A';
+          conversionCell.classList.add('na-value');
+        }
+      }
+    });
+  }
+
+  function shortenAddress(address) {
+    if (!address || typeof address !== 'string') {
+      return '';
+    }
+    if (address.length <= 12) {
+      return address;
+    }
+    return `${address.slice(0, 6)}…${address.slice(-6)}`;
+  }
+
+  function createExplorerLink(href, label) {
+    const link = document.createElement('a');
+    link.href = href;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = label;
+    return link;
+  }
+
+  async function refreshData({ reason } = {}) {
+    if (isRefreshing) {
+      return;
+    }
+
+    isRefreshing = true;
+    if (updatedElement) {
+      updatedElement.textContent = 'Refreshing data…';
+    }
+
+    const fetchStart = performance.now();
+    const warnings = [];
+    let allowlistLog = Array.isArray(lastSnapshot && lastSnapshot.allowlistLog) ? [...lastSnapshot.allowlistLog] : [];
+
+    try {
+      const entrantsResult = await fetchEntrants();
+      const weekResults = [];
+
+      for (const config of weeksConfig) {
+        const weekStart = performance.now();
+        const result = await fetchWeekResult(config, entrantsResult, allowlistLog);
+        result.durationMs = performance.now() - weekStart;
+        console.info('[Algoland] Week fetch complete', {
+          week: config.week,
+          durationMs: result.durationMs,
+          completed: result.completedCount,
+        });
+        weekResults.push(result);
+        if (Array.isArray(result.noticeMessages)) {
+          result.noticeMessages.forEach((message) => {
+            warnings.push({ type: message.type || 'warning', text: `Week ${config.week}: ${message.text}` });
+          });
+        }
+      }
+
+      const entrantsCount = entrantsResult.addresses.size;
+      const previousEntrants = lastSnapshot && typeof lastSnapshot.entrants?.count === 'number' ? lastSnapshot.entrants.count : null;
+      if (previousEntrants && entrantsCount < previousEntrants * 0.9) {
+        warnings.push({
+          type: 'warning',
+          text: `Entrants count dropped from ${numberFormatter.format(previousEntrants)} to ${numberFormatter.format(entrantsCount)}. This may indicate indexer lag.`,
+        });
+      }
+
+      const snapshot = {
+        timestamp: new Date().toISOString(),
+        provider: providerBase,
+        campaign: CAMPAIGN_NAME,
+        entrants: {
+          count: entrantsCount,
+          addresses: Array.from(entrantsResult.addresses),
+        },
+        weeks: weekResults.map((week) => ({
+          week: week.week,
+          assetId: week.assetId,
+          distributors: week.distributors,
+          completedCount: week.completedCount,
+          completedAddresses: Array.from(week.completedAddresses),
+          conversion: week.conversion,
+          decimals: week.decimals,
+          warnings: week.warnings,
+          syncing: week.syncing,
+          verificationSample: week.verificationSample,
+          allowlistEmpty: week.allowlistEmpty,
+          adminAddresses: Array.from(week.adminAddresses),
+          durationMs: week.durationMs,
+          allowlistSuggestions: week.allowlistSuggestions,
+          comingSoon: week.comingSoon,
+        })),
+        durations: {
+          entrantsMs: entrantsResult.durationMs,
+          totalMs: performance.now() - fetchStart,
+        },
+        providerUsed: providerBase,
+        cacheExpiresAt: Date.now() + CACHE_MS,
+        allowlistLog: trimAllowlistLog(allowlistLog),
+      };
+
+      persistSnapshot(snapshot);
+      lastSnapshot = snapshot;
+      renderSnapshot(snapshot, { fromCache: false, warnings });
+      console.info('[Algoland] Refresh complete', {
+        entrants: entrantsCount,
+        totalDurationMs: snapshot.durations.totalMs,
+        reason,
+      });
+    } catch (error) {
+      console.error('[Algoland] Refresh failed', error);
+      const cacheSnapshot = lastSnapshot || loadSnapshot();
+      const cacheWarnings = [{
+        type: 'warning',
+        text: `Live refresh failed: ${error.message}. Displaying cached results where available.`,
+      }];
+      if (cacheSnapshot) {
+        renderSnapshot(cacheSnapshot, { fromCache: true, warnings: cacheWarnings, cacheNotice: true });
+      } else {
+        renderAlerts(cacheWarnings);
+      }
+    } finally {
+      isRefreshing = false;
+    }
+  }
+
+  async function fetchEntrants() {
+    const entrants = new Set();
+    let nextToken = null;
+    const start = performance.now();
+
+    while (true) {
+      const query = new URL(`/v2/applications/${APP_ID}/accounts`, providerBase);
+      query.searchParams.set('limit', '1000');
+      if (nextToken) {
+        query.searchParams.set('next', nextToken);
+      }
+      const response = await fetchWithRetry(query);
+      const accounts = Array.isArray(response.accounts) ? response.accounts : [];
+      accounts.forEach((account) => {
+        if (account && account.address) {
+          entrants.add(account.address);
+        }
+      });
+      nextToken = response['next-token'];
+      if (!nextToken) {
+        break;
+      }
+    }
+
+    const durationMs = performance.now() - start;
+    console.info(`[Algoland] Entrants fetched: ${entrants.size} wallets in ${durationMs.toFixed(0)}ms`);
+    return { addresses: entrants, durationMs };
+  }
+
+  async function fetchWeekResult(config, entrantsResult, allowlistLog) {
+    const result = {
+      week: config.week,
+      assetId: config.assetId,
+      distributors: [...config.distributors],
+      completedAddresses: new Set(),
+      completedCount: 0,
+      conversion: null,
+      decimals: 0,
+      warnings: [],
+      noticeMessages: [],
+      syncing: false,
+      allowlistEmpty: config.distributors.length === 0,
+      adminAddresses: new Set(),
+      allowlistSuggestions: [],
+      verificationSample: { checked: [], mismatches: [] },
+    };
+
+    result.comingSoon = !config.assetId;
+
+    if (!config.assetId) {
+      result.conversion = null;
+      return result;
+    }
+
+    if (result.allowlistEmpty) {
+      result.warnings.push('Distributor allowlist is empty. Completed counts disabled.');
+      return result;
+    }
+
+    const assetDetails = await fetchAssetDetails(config.assetId);
+    result.decimals = assetDetails.decimals;
+    result.adminAddresses = assetDetails.adminAddresses;
+
+    if (assetDetails.decimals !== 0) {
+      result.warnings.push(`Asset decimals is ${assetDetails.decimals}. Amounts will be normalised.`);
+    }
+
+    const allowlist = new Set(config.distributors);
+    const adminSet = assetDetails.adminAddresses;
+    let nextToken = null;
+
+    while (true) {
+      const query = new URL(`/v2/assets/${config.assetId}/transactions`, providerBase);
+      query.searchParams.set('tx-type', 'axfer');
+      query.searchParams.set('limit', '1000');
+      if (nextToken) {
+        query.searchParams.set('next', nextToken);
+      }
+
+      const response = await fetchWithRetry(query);
+      const transactions = Array.isArray(response.transactions) ? response.transactions : [];
+
+      transactions.forEach((transaction) => {
+        const transfer = transaction && transaction['asset-transfer-transaction'];
+        if (!transfer || typeof transfer.amount !== 'number') {
+          return;
+        }
+
+        const amount = transfer.amount;
+        if (amount <= 0) {
+          return;
+        }
+
+        const senderAddress = transfer.sender || transaction.sender;
+        const feePayer = transaction.sender;
+        const isDistributor = allowlist.has(senderAddress) || allowlist.has(feePayer);
+
+        if (!isDistributor) {
+          if (senderAddress && senderAddress.startsWith(KNOWN_ORGANISER_PREFIX)) {
+            if (!allowlistLog.some((entry) => entry.week === config.week && entry.address === senderAddress)) {
+              const logEntry = { week: config.week, address: senderAddress, notedAt: new Date().toISOString() };
+              allowlistLog.push(logEntry);
+              result.allowlistSuggestions.push(logEntry);
+              console.info('[Algoland] Observed organiser-prefixed sender outside allowlist', {
+                week: config.week,
+                sender: senderAddress,
+              });
+              result.noticeMessages.push({
+                type: 'info',
+                text: `Observed organiser-prefixed sender ${shortenAddress(senderAddress)} not on allowlist. Review required before inclusion.`,
+              });
+            }
+          }
+          return;
+        }
+
+        const receiver = transfer.receiver;
+        if (!receiver || adminSet.has(receiver)) {
+          return;
+        }
+
+        result.completedAddresses.add(receiver);
+      });
+
+      nextToken = response['next-token'];
+      if (!nextToken) {
+        break;
+      }
+    }
+
+    result.completedCount = result.completedAddresses.size;
+    if (entrantsResult.addresses.size > 0) {
+      result.conversion = result.completedCount / entrantsResult.addresses.size;
+    }
+
+    if (result.completedCount > 0) {
+      const verification = await verifyBalances(config.assetId, result.decimals, Array.from(result.completedAddresses));
+      result.verificationSample = verification;
+      if (verification.mismatches.length > 0) {
+        result.syncing = true;
+        result.warnings.push(`Indexer still syncing balances for ${verification.mismatches.length} sampled wallet(s).`);
+      }
+    }
+
+    console.info('[Algoland] Week summary', {
+      week: config.week,
+      assetId: config.assetId || null,
+      completed: result.completedCount,
+      conversion: result.conversion,
+    });
+
+    return result;
+  }
+
+  async function fetchAssetDetails(assetId) {
+    const response = await fetchWithRetry(new URL(`/v2/assets/${assetId}`, providerBase));
+    const asset = response.asset || {};
+    const params = asset.params || {};
+    const decimals = typeof params.decimals === 'number' ? params.decimals : 0;
+    const adminAddresses = new Set();
+    ['creator', 'manager', 'reserve', 'clawback'].forEach((key) => {
+      if (asset[key]) {
+        adminAddresses.add(asset[key]);
+      }
+      if (params[key]) {
+        adminAddresses.add(params[key]);
+      }
+    });
+    return { decimals, adminAddresses };
+  }
+
+  async function verifyBalances(assetId, decimals, addresses) {
+    const pool = [...addresses];
+    for (let i = pool.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      const temp = pool[i];
+      pool[i] = pool[j];
+      pool[j] = temp;
+    }
+    const sample = pool.slice(0, Math.min(3, pool.length));
+    const mismatches = [];
+    const threshold = decimals > 0 ? Math.pow(10, decimals) : 1;
+
+    for (const address of sample) {
+      try {
+        const response = await fetchWithRetry(new URL(`/v2/accounts/${address}`, providerBase));
+        const account = response.account || {};
+        const assets = Array.isArray(account.assets) ? account.assets : [];
+        const holding = assets.find((entry) => String(entry['asset-id']) === String(assetId));
+        const amount = holding ? Number(holding.amount) : 0;
+        if (!holding || Number.isNaN(amount) || amount < threshold) {
+          mismatches.push(address);
+        }
+      } catch (error) {
+        mismatches.push(address);
+      }
+    }
+
+    return { checked: sample, mismatches };
+  }
+
+  async function fetchWithRetry(url, attempt = 0) {
+    const requestUrl = typeof url === 'string' ? url : url.toString();
+    const started = performance.now();
+
+    try {
+      const response = await fetch(requestUrl, {
+        headers: { Accept: 'application/json' },
+        mode: 'cors',
+      });
+
+      if (!response.ok) {
+        if ((response.status === 429 || response.status >= 500) && attempt + 1 < MAX_RETRIES) {
+          const delayMs = Math.pow(2, attempt) * RETRY_BASE_DELAY_MS;
+          await delay(delayMs);
+          return fetchWithRetry(url, attempt + 1);
+        }
+
+        throw new Error(`Indexer request failed with status ${response.status}`);
+      }
+
+      const json = await response.json();
+      const duration = performance.now() - started;
+      console.info(`[Algoland] ${requestUrl} completed in ${duration.toFixed(0)}ms`);
+      return json;
+    } catch (error) {
+      if (attempt + 1 < MAX_RETRIES) {
+        const delayMs = Math.pow(2, attempt) * RETRY_BASE_DELAY_MS;
+        await delay(delayMs);
+        return fetchWithRetry(url, attempt + 1);
+      }
+      throw error;
+    }
+  }
+
+  function delay(ms) {
+    return new Promise((resolve) => window.setTimeout(resolve, ms));
+  }
+
+  function persistSnapshot(snapshot) {
+    try {
+      window.localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(snapshot));
+    } catch (error) {
+      console.warn('[Algoland] Unable to persist snapshot', error);
+    }
+  }
+
+  function loadSnapshot() {
+    try {
+      const raw = window.localStorage.getItem(SNAPSHOT_KEY);
+      if (!raw) {
+        return null;
+      }
+      const parsed = JSON.parse(raw);
+      if (!parsed || !parsed.timestamp) {
+        return null;
+      }
+      return parsed;
+    } catch (error) {
+      console.warn('[Algoland] Unable to load snapshot', error);
+      return null;
+    }
+  }
+
+  function trimAllowlistLog(log) {
+    if (!Array.isArray(log)) {
+      return [];
+    }
+    const unique = [];
+    log.forEach((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+      const exists = unique.some((item) => item.week === entry.week && item.address === entry.address);
+      if (!exists) {
+        unique.push(entry);
+      }
+    });
+    return unique.slice(-50);
+  }
+
+  function renderSnapshot(snapshot, { fromCache, warnings, cacheNotice } = {}) {
+    if (!snapshot || !table) {
+      return;
+    }
+
+    const entrantsCount = typeof snapshot.entrants?.count === 'number' ? snapshot.entrants.count : 0;
+    setSummaryValue(summaryElements.entrants, entrantsCount);
+
+    const week1 = snapshot.weeks.find((week) => week.week === 1);
+    const week2 = snapshot.weeks.find((week) => week.week === 2);
+    setSummaryValue(summaryElements.week1, week1 && typeof week1.completedCount === 'number' ? week1.completedCount : null);
+    setSummaryValue(summaryElements.week2, week2 && typeof week2.completedCount === 'number' ? week2.completedCount : null);
+
+    const overallCompleted = snapshot.weeks.reduce((total, week) => {
+      if (!week || week.comingSoon || week.allowlistEmpty || typeof week.completedCount !== 'number') {
+        return total;
+      }
+      return total + week.completedCount;
+    }, 0);
+    setSummaryValue(summaryElements.overall, overallCompleted);
+
+    snapshot.weeks.forEach((week) => {
+      const row = table.querySelector(`tr[data-week="${week.week}"]`);
+      if (!row) {
+        return;
+      }
+
+      const entrantsCell = row.querySelector('[data-col="entrants"]');
+      if (entrantsCell) {
+        entrantsCell.textContent = numberFormatter.format(entrantsCount);
+      }
+
+      const completedCell = row.querySelector('[data-col="completed"]');
+      const conversionCell = row.querySelector('[data-col="conversion"]');
+
+      if (!week.assetId) {
+        if (completedCell) {
+          completedCell.textContent = 'N/A';
+          completedCell.classList.add('na-value');
+        }
+        if (conversionCell) {
+          conversionCell.textContent = 'N/A';
+          conversionCell.classList.add('na-value');
+        }
+        row.classList.remove('is-syncing');
+        return;
+      }
+
+      const note = completedCell ? completedCell.querySelector('.status-note') : null;
+      if (note) {
+        note.remove();
+      }
+
+      if (completedCell) {
+        if (week.allowlistEmpty || typeof week.completedCount !== 'number') {
+          completedCell.textContent = 'N/A';
+          completedCell.classList.add('na-value');
+        } else {
+          completedCell.textContent = numberFormatter.format(week.completedCount);
+          completedCell.classList.remove('na-value');
+        }
+      }
+
+      if (conversionCell) {
+        if (week.allowlistEmpty || typeof week.conversion !== 'number') {
+          conversionCell.textContent = 'N/A';
+          conversionCell.classList.add('na-value');
+        } else {
+          conversionCell.textContent = percentFormatter.format(week.conversion);
+          conversionCell.classList.remove('na-value');
+        }
+      }
+
+      if (completedCell && week.warnings && week.warnings.length > 0) {
+        const statusNote = document.createElement('div');
+        statusNote.className = 'status-note';
+        statusNote.textContent = week.warnings[0];
+        completedCell.appendChild(statusNote);
+      }
+
+      row.classList.toggle('is-syncing', Boolean(week.syncing));
+    });
+
+    if (updatedElement) {
+      const timestamp = snapshot.timestamp ? new Date(snapshot.timestamp) : new Date();
+      const parts = [
+        `Last updated ${timestamp.toLocaleString()}`,
+        `Provider: ${snapshot.provider || snapshot.providerUsed || providerBase}`,
+      ];
+      if (fromCache) {
+        parts.push('served from cache');
+      }
+      updatedElement.textContent = parts.join(' • ');
+    }
+
+    const alertMessages = Array.isArray(warnings) ? [...warnings] : [];
+    const timestampValue = snapshot.timestamp ? Date.parse(snapshot.timestamp) : NaN;
+    if (!Number.isNaN(timestampValue)) {
+      const ageMs = Date.now() - timestampValue;
+      if (ageMs > CACHE_MS) {
+        alertMessages.push({
+          type: 'warning',
+          text: 'Snapshot age exceeds 10 minutes. Counts may not include the most recent activity.',
+        });
+      }
+    }
+    snapshot.weeks.forEach((week) => {
+      if (Array.isArray(week.warnings)) {
+        week.warnings.forEach((warning) => {
+          alertMessages.push({ type: 'warning', text: `Week ${week.week}: ${warning}` });
+        });
+      }
+      if (Array.isArray(week.allowlistSuggestions) && week.allowlistSuggestions.length > 0) {
+        week.allowlistSuggestions.forEach((entry) => {
+          alertMessages.push({
+            type: 'info',
+            text: `Week ${week.week}: Observed organiser sender ${shortenAddress(entry.address)} awaiting verification.`,
+          });
+        });
+      }
+    });
+
+    if (cacheNotice) {
+      alertMessages.push({ type: 'info', text: 'Cached results remain valid for 10 minutes. Live refresh will retry automatically.' });
+    }
+
+    renderAlerts(alertMessages);
+  }
+
+  function setSummaryValue(element, value) {
+    if (!element) {
+      return;
+    }
+    if (typeof value === 'number') {
+      element.textContent = numberFormatter.format(value);
+    } else {
+      element.textContent = '—';
+    }
+  }
+
+  function renderAlerts(messages) {
+    if (!alertsContainer) {
+      return;
+    }
+
+    alertsContainer.innerHTML = '';
+
+    const filtered = Array.isArray(messages)
+      ? messages.filter((message) => message && typeof message.text === 'string' && message.text.trim().length > 0)
+      : [];
+
+    if (filtered.length === 0) {
+      alertsContainer.hidden = true;
+      return;
+    }
+
+    alertsContainer.hidden = false;
+
+    filtered.forEach((message) => {
+      const alert = document.createElement('div');
+      alert.className = 'algoland-alert';
+      if (message.type === 'info') {
+        alert.classList.add('algoland-alert--info');
+      }
+      alert.textContent = message.text;
+      alertsContainer.appendChild(alert);
+    });
+  }
+})();

--- a/contact.html
+++ b/contact.html
@@ -67,6 +67,7 @@
         <a href="about.html">About</a>
         <a href="services.html">Services</a>
         <a href="how-we-work.html">How we work</a>
+        <a href="algoland.html">Algoland</a>
         <a href="contact.html" aria-current="page">Contact</a>
       </nav>
     </div>

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -87,6 +87,7 @@
         <a href="about.html">About</a>
         <a href="services.html">Services</a>
         <a href="how-we-work.html" aria-current="page">How we work</a>
+        <a href="algoland.html">Algoland</a>
         <a href="contact.html">Contact</a>
       </nav>
     </div>

--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
         <a href="about.html">About</a>
         <a href="services.html">Services</a>
         <a href="how-we-work.html">How we work</a>
+        <a href="algoland.html">Algoland</a>
         <a href="contact.html">Contact</a>
       </nav>
     </div>

--- a/privacy.html
+++ b/privacy.html
@@ -57,6 +57,7 @@
         <a href="about.html">About</a>
         <a href="services.html">Services</a>
         <a href="how-we-work.html">How we work</a>
+        <a href="algoland.html">Algoland</a>
         <a href="contact.html">Contact</a>
       </nav>
     </div>

--- a/services.html
+++ b/services.html
@@ -71,6 +71,7 @@
         <a href="about.html">About</a>
         <a href="services.html" aria-current="page">Services</a>
         <a href="how-we-work.html">How we work</a>
+        <a href="algoland.html">Algoland</a>
         <a href="contact.html">Contact</a>
       </nav>
     </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,4 +18,7 @@
   <url>
     <loc>https://www.emnetcm.com/privacy.html</loc>
   </url>
+  <url>
+    <loc>https://www.emnetcm.com/algoland.html</loc>
+  </url>
 </urlset>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1113,6 +1113,200 @@ body.about-page .hero-logo {
   height: auto;
 }
 
+/* Algoland page */
+.algoland-page .algoland-hero {
+  max-width: 840px;
+}
+
+.algoland-page .section-lede {
+  font-size: 1.1rem;
+  color: rgba(240, 240, 240, 0.9);
+}
+
+.algoland-page .summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.algoland-page .summary-card {
+  background: rgba(18, 18, 18, 0.9);
+  border: 1px solid rgba(255, 46, 189, 0.2);
+  border-radius: 18px;
+  padding: 24px;
+  display: grid;
+  gap: 6px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
+}
+
+.algoland-page .summary-card h2 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.algoland-page .summary-count {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.5rem);
+  font-weight: 700;
+  color: #26d3c5;
+}
+
+.algoland-page .summary-meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.algoland-page .last-updated {
+  margin-top: 24px;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.algoland-alerts {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.algoland-alert {
+  border-radius: 14px;
+  padding: 14px 18px;
+  border-left: 4px solid #ffb347;
+  background: rgba(255, 179, 71, 0.08);
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.algoland-alert--info {
+  border-left-color: #26d3c5;
+  background: rgba(38, 211, 197, 0.08);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.data-table caption {
+  text-align: left;
+  padding: 18px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.data-table thead th {
+  text-align: left;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(17, 17, 17, 0.9);
+  padding: 12px 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.data-table tbody td,
+.data-table tbody th {
+  padding: 14px 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  vertical-align: top;
+}
+
+.data-table tbody th {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.data-table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.algoland-table td[data-col="links"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.algoland-table td[data-col="links"] a {
+  color: #26d3c5;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.algoland-table td[data-col="links"] a:hover,
+.algoland-table td[data-col="links"] a:focus-visible {
+  color: #ff5bd0;
+  outline: none;
+}
+
+.algoland-table .address-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(17, 17, 17, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.85rem;
+  line-height: 1.3;
+}
+
+.algoland-table .status-note {
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.64);
+}
+
+.algoland-table tr.is-syncing {
+  position: relative;
+}
+
+.algoland-table tr.is-syncing::after {
+  content: "Syncing";
+  position: absolute;
+  top: 8px;
+  right: 18px;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #ffb347;
+}
+
+.algoland-table .warning-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: #ffb347;
+}
+
+.algoland-table .warning-badge::before {
+  content: "⚠";
+  font-size: 0.9rem;
+}
+
+.algoland-table .na-value {
+  color: rgba(255, 255, 255, 0.5);
+  font-style: italic;
+}
+
+.algoland-page .table-wrapper {
+  background: rgba(0, 0, 0, 0.4);
+}
+
 @media (min-width: 768px) {
   .site-footer {
     text-align: right;
@@ -1336,6 +1530,14 @@ body.cookie-banner-visible {
 
   .services-final-cta {
     margin-inline: 0;
+  }
+
+  .algoland-page .summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .data-table {
+    min-width: 520px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add an Algoland progress page with campaign summary metrics, explorer links, and 13-week placeholders
- build a client-side data module that reads Algorand indexer data with pagination, caching, warnings, and balance verification
- extend shared styles and navigation so the new dashboard matches the existing site look and is linked site-wide

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68def7887b748322bba3142bd7472eb2