### PR TITLE
Add backend API for Algoland data and update dashboard client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+backend/node_modules/
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -59,3 +59,6 @@ To publish with GitHub Pages:
 2. Update the favicon at `assets/favicon.png`.
 3. Swap the social preview image at `assets/og-image.png` if you have a different share card.
 4. Edit page copy directly in the relevant HTML file. Each page includes SEO, Open Graph, and Twitter card metadata that can be adjusted as required.
+
+## Algoland data backend
+The `/algoland` dashboard now reads badge completion and entrant counts from a dedicated backend service in [`backend/`](backend/). Deploy this Express app to Render (or another Node-compatible host), configure the `INDEXER_BASE` and `ALLOWED_ORIGINS` environment variables, and point the page at the service by updating the `data-api-base` attribute on `<main data-algoland-root>`.

--- a/algoland.html
+++ b/algoland.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Algoland progress | EmNet Community Management Limited.</title>
   <meta name="description" content="Live Algorand Algoland campaign entrants and badge completion counts tracked directly from the blockchain.">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self' https://mainnet-idx.algonode.cloud; font-src 'self'; form-action 'self'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-BkXFec1CkFMHthIcTLpcazC7dGyWpjlM8smsiOdKG4c='; style-src 'self'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; connect-src 'self' https://api.emnetcm.com https://algoland-api.onrender.com; font-src 'self'; form-action 'self'; img-src 'self' data: https://www.emnetcm.com; manifest-src 'self'; object-src 'none'; script-src 'self' 'sha256-ZcCF+1SEEOHp8W4FJJWDG4l2iX5saBqnGTJ2nz2rrMw='; style-src 'self'">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="keywords" content="Algoland campaign analytics, Algorand community reporting, badge completion tracking">
   <meta name="author" content="EmNet Community Management Limited">
@@ -80,7 +80,7 @@
     </div>
   </header>
 
-  <main data-algoland-root data-indexer-provider="https://mainnet-idx.algonode.cloud">
+  <main data-algoland-root data-api-base="https://api.emnetcm.com">
     <section class="container section algoland-hero">
       <h1>Algoland progress</h1>
       <p class="section-lede">Live on chain counts of challenge entrants and badge completions.</p>

--- a/assets/algoland.js
+++ b/assets/algoland.js
@@ -4,22 +4,11 @@
     return;
   }
 
-  const APP_ID = 3215540125;
-  const CAMPAIGN_NAME = 'Algoland retail campaign';
-  const KNOWN_ORGANISER_PREFIX = 'LANDBACKOF354GJUI4HMC6G2G3EGHEXDUZ4YEDDTJSSTIAZ3X4M5TLX3BI';
-  const DEFAULT_DISTRIBUTOR = 'HHADCZKQV24QDCBER5GTOH7BOLF4ZQ6WICNHAA3GZUECIMJXIIMYBIWEZM';
-  const SNAPSHOT_KEY = 'emnet.algoland.snapshot.v1';
-  const CACHE_MS = 10 * 60 * 1000;
+  const API_BASE = normaliseBase(root.dataset.apiBase || window.EMNET_ALGOLAND_API_BASE || '');
+  const SNAPSHOT_KEY = 'emnet.algoland.snapshot.v2';
   const REFRESH_INTERVAL_MS = 10 * 60 * 1000;
-  const MAX_RETRIES = 4;
-  const RETRY_BASE_DELAY_MS = 600;
-  const providerBase = root.dataset.indexerProvider || window.EMNET_INDEXER_PROVIDER || 'https://mainnet-idx.algonode.cloud';
-  const numberFormatter = new Intl.NumberFormat('en-GB');
-  const percentFormatter = new Intl.NumberFormat('en-GB', {
-    style: 'percent',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
+  const DEFAULT_DISTRIBUTOR = 'HHADCZKQV24QDCBER5GTOH7BOLF4ZQ6WICNHAA3GZUECIMJXIIMYBIWEZM';
+  const APP_ID = 3215540125;
 
   const weeksConfig = [
     { week: 1, assetId: '3215542831', distributors: [DEFAULT_DISTRIBUTOR] },
@@ -37,6 +26,13 @@
     { week: 13, assetId: '', distributors: [DEFAULT_DISTRIBUTOR] },
   ];
 
+  const numberFormatter = new Intl.NumberFormat('en-GB');
+  const percentFormatter = new Intl.NumberFormat('en-GB', {
+    style: 'percent',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
   const summaryElements = {
     entrants: root.querySelector('[data-summary="entrants"]'),
     week1: root.querySelector('[data-summary="week-1"]'),
@@ -46,35 +42,50 @@
   const alertsContainer = root.querySelector('[data-algoland-alerts]');
   const table = root.querySelector('[data-algoland-table]');
   const updatedElement = root.querySelector('[data-algoland-updated]');
-  const appExplorerUrl = `https://allo.info/application/${APP_ID}`;
 
-  let lastSnapshot = loadSnapshot();
-  let isRefreshing = false;
+  const state = {
+    snapshot: loadSnapshot(),
+    isRefreshing: false,
+  };
 
-  console.info('[Algoland] Initialised Algoland dashboard', { provider: providerBase });
+  console.info('[Algoland] Initialised Algoland dashboard', { apiBase: API_BASE || 'relative' });
 
   initialiseStaticTable();
 
-  if (lastSnapshot) {
-    renderSnapshot(lastSnapshot, { fromCache: true, warnings: [] });
+  if (state.snapshot) {
+    renderSnapshot(state.snapshot, { fromCache: true, alerts: [] });
   }
 
-  refreshData({ reason: 'initial load' });
+  refreshData('initial load');
   window.setInterval(() => {
-    refreshData({ reason: 'scheduled interval' });
+    refreshData('scheduled interval');
   }, REFRESH_INTERVAL_MS);
+
+  function normaliseBase(base) {
+    if (typeof base !== 'string' || base.length === 0) {
+      return '';
+    }
+    return base.replace(/\/+$/, '');
+  }
+
+  function buildApiUrl(path) {
+    const trimmedPath = path.startsWith('/') ? path : `/${path}`;
+    if (!API_BASE) {
+      return trimmedPath;
+    }
+    return `${API_BASE}${trimmedPath}`;
+  }
 
   function initialiseStaticTable() {
     if (!table) {
       return;
     }
-
+    const appExplorerUrl = `https://allo.info/application/${APP_ID}`;
     weeksConfig.forEach((config) => {
       const row = table.querySelector(`tr[data-week="${config.week}"]`);
       if (!row) {
         return;
       }
-
       const badgeCell = row.querySelector('[data-col="badge"]');
       if (badgeCell) {
         if (config.assetId) {
@@ -85,7 +96,6 @@
           badgeCell.classList.add('na-value');
         }
       }
-
       const distributorCell = row.querySelector('[data-col="distributor"]');
       if (distributorCell) {
         distributorCell.textContent = '';
@@ -97,7 +107,6 @@
           distributorCell.appendChild(pill);
         });
       }
-
       const linksCell = row.querySelector('[data-col="links"]');
       if (linksCell) {
         linksCell.textContent = '';
@@ -110,10 +119,9 @@
           linksCell.appendChild(createExplorerLink(`https://allo.info/address/${address}`, label));
         });
       }
-
-      const completedCell = row.querySelector('[data-col="completed"]');
-      const conversionCell = row.querySelector('[data-col="conversion"]');
       if (!config.assetId) {
+        const completedCell = row.querySelector('[data-col="completed"]');
+        const conversionCell = row.querySelector('[data-col="conversion"]');
         if (completedCell) {
           completedCell.textContent = 'N/A';
           completedCell.classList.add('na-value');
@@ -145,556 +153,317 @@
     return link;
   }
 
-  async function refreshData({ reason } = {}) {
-    if (isRefreshing) {
-      return;
-    }
-
-    isRefreshing = true;
-    if (updatedElement) {
-      updatedElement.textContent = 'Refreshing data…';
-    }
-
-    const fetchStart = performance.now();
-    const warnings = [];
-    let allowlistLog = Array.isArray(lastSnapshot && lastSnapshot.allowlistLog) ? [...lastSnapshot.allowlistLog] : [];
-
-    try {
-      const entrantsResult = await fetchEntrants();
-      const weekResults = [];
-
-      for (const config of weeksConfig) {
-        const weekStart = performance.now();
-        const result = await fetchWeekResult(config, entrantsResult, allowlistLog);
-        result.durationMs = performance.now() - weekStart;
-        console.info('[Algoland] Week fetch complete', {
-          week: config.week,
-          durationMs: result.durationMs,
-          completed: result.completedCount,
-        });
-        weekResults.push(result);
-        if (Array.isArray(result.noticeMessages)) {
-          result.noticeMessages.forEach((message) => {
-            warnings.push({ type: message.type || 'warning', text: `Week ${config.week}: ${message.text}` });
-          });
-        }
-      }
-
-      const entrantsCount = entrantsResult.addresses.size;
-      const previousEntrants = lastSnapshot && typeof lastSnapshot.entrants?.count === 'number' ? lastSnapshot.entrants.count : null;
-      if (previousEntrants && entrantsCount < previousEntrants * 0.9) {
-        warnings.push({
-          type: 'warning',
-          text: `Entrants count dropped from ${numberFormatter.format(previousEntrants)} to ${numberFormatter.format(entrantsCount)}. This may indicate indexer lag.`,
-        });
-      }
-
-      const snapshot = {
-        timestamp: new Date().toISOString(),
-        provider: providerBase,
-        campaign: CAMPAIGN_NAME,
-        entrants: {
-          count: entrantsCount,
-          addresses: Array.from(entrantsResult.addresses),
-        },
-        weeks: weekResults.map((week) => ({
-          week: week.week,
-          assetId: week.assetId,
-          distributors: week.distributors,
-          completedCount: week.completedCount,
-          completedAddresses: Array.from(week.completedAddresses),
-          conversion: week.conversion,
-          decimals: week.decimals,
-          warnings: week.warnings,
-          syncing: week.syncing,
-          verificationSample: week.verificationSample,
-          allowlistEmpty: week.allowlistEmpty,
-          adminAddresses: Array.from(week.adminAddresses),
-          durationMs: week.durationMs,
-          allowlistSuggestions: week.allowlistSuggestions,
-          comingSoon: week.comingSoon,
-        })),
-        durations: {
-          entrantsMs: entrantsResult.durationMs,
-          totalMs: performance.now() - fetchStart,
-        },
-        providerUsed: providerBase,
-        cacheExpiresAt: Date.now() + CACHE_MS,
-        allowlistLog: trimAllowlistLog(allowlistLog),
-      };
-
-      persistSnapshot(snapshot);
-      lastSnapshot = snapshot;
-      renderSnapshot(snapshot, { fromCache: false, warnings });
-      console.info('[Algoland] Refresh complete', {
-        entrants: entrantsCount,
-        totalDurationMs: snapshot.durations.totalMs,
-        reason,
-      });
-    } catch (error) {
-      console.error('[Algoland] Refresh failed', error);
-      const cacheSnapshot = lastSnapshot || loadSnapshot();
-      const cacheWarnings = [{
-        type: 'warning',
-        text: `Live refresh failed: ${error.message}. Displaying cached results where available.`,
-      }];
-      if (cacheSnapshot) {
-        renderSnapshot(cacheSnapshot, { fromCache: true, warnings: cacheWarnings, cacheNotice: true });
-      } else {
-        renderAlerts(cacheWarnings);
-      }
-    } finally {
-      isRefreshing = false;
-    }
-  }
-
-  async function fetchEntrants() {
-    const entrants = new Set();
-    let nextToken = null;
-    const start = performance.now();
-
-    while (true) {
-      const query = new URL(`/v2/applications/${APP_ID}/accounts`, providerBase);
-      query.searchParams.set('limit', '1000');
-      if (nextToken) {
-        query.searchParams.set('next', nextToken);
-      }
-      const response = await fetchWithRetry(query);
-      const accounts = Array.isArray(response.accounts) ? response.accounts : [];
-      accounts.forEach((account) => {
-        if (account && account.address) {
-          entrants.add(account.address);
-        }
-      });
-      nextToken = response['next-token'];
-      if (!nextToken) {
-        break;
-      }
-    }
-
-    const durationMs = performance.now() - start;
-    console.info(`[Algoland] Entrants fetched: ${entrants.size} wallets in ${durationMs.toFixed(0)}ms`);
-    return { addresses: entrants, durationMs };
-  }
-
-  async function fetchWeekResult(config, entrantsResult, allowlistLog) {
-    const result = {
-      week: config.week,
-      assetId: config.assetId,
-      distributors: [...config.distributors],
-      completedAddresses: new Set(),
-      completedCount: 0,
-      conversion: null,
-      decimals: 0,
-      warnings: [],
-      noticeMessages: [],
-      syncing: false,
-      allowlistEmpty: config.distributors.length === 0,
-      adminAddresses: new Set(),
-      allowlistSuggestions: [],
-      verificationSample: { checked: [], mismatches: [] },
-    };
-
-    result.comingSoon = !config.assetId;
-
-    if (!config.assetId) {
-      result.conversion = null;
-      return result;
-    }
-
-    if (result.allowlistEmpty) {
-      result.warnings.push('Distributor allowlist is empty. Completed counts disabled.');
-      return result;
-    }
-
-    const assetDetails = await fetchAssetDetails(config.assetId);
-    result.decimals = assetDetails.decimals;
-    result.adminAddresses = assetDetails.adminAddresses;
-
-    if (assetDetails.decimals !== 0) {
-      result.warnings.push(`Asset decimals is ${assetDetails.decimals}. Amounts will be normalised.`);
-    }
-
-    const allowlist = new Set(config.distributors);
-    const adminSet = assetDetails.adminAddresses;
-    let nextToken = null;
-
-    while (true) {
-      const query = new URL(`/v2/assets/${config.assetId}/transactions`, providerBase);
-      query.searchParams.set('tx-type', 'axfer');
-      query.searchParams.set('limit', '1000');
-      if (nextToken) {
-        query.searchParams.set('next', nextToken);
-      }
-
-      const response = await fetchWithRetry(query);
-      const transactions = Array.isArray(response.transactions) ? response.transactions : [];
-
-      transactions.forEach((transaction) => {
-        const transfer = transaction && transaction['asset-transfer-transaction'];
-        if (!transfer || typeof transfer.amount !== 'number') {
-          return;
-        }
-
-        const amount = transfer.amount;
-        if (amount <= 0) {
-          return;
-        }
-
-        const senderAddress = transfer.sender || transaction.sender;
-        const feePayer = transaction.sender;
-        const isDistributor = allowlist.has(senderAddress) || allowlist.has(feePayer);
-
-        if (!isDistributor) {
-          if (senderAddress && senderAddress.startsWith(KNOWN_ORGANISER_PREFIX)) {
-            if (!allowlistLog.some((entry) => entry.week === config.week && entry.address === senderAddress)) {
-              const logEntry = { week: config.week, address: senderAddress, notedAt: new Date().toISOString() };
-              allowlistLog.push(logEntry);
-              result.allowlistSuggestions.push(logEntry);
-              console.info('[Algoland] Observed organiser-prefixed sender outside allowlist', {
-                week: config.week,
-                sender: senderAddress,
-              });
-              result.noticeMessages.push({
-                type: 'info',
-                text: `Observed organiser-prefixed sender ${shortenAddress(senderAddress)} not on allowlist. Review required before inclusion.`,
-              });
-            }
-          }
-          return;
-        }
-
-        const receiver = transfer.receiver;
-        if (!receiver || adminSet.has(receiver)) {
-          return;
-        }
-
-        result.completedAddresses.add(receiver);
-      });
-
-      nextToken = response['next-token'];
-      if (!nextToken) {
-        break;
-      }
-    }
-
-    result.completedCount = result.completedAddresses.size;
-    if (entrantsResult.addresses.size > 0) {
-      result.conversion = result.completedCount / entrantsResult.addresses.size;
-    }
-
-    if (result.completedCount > 0) {
-      const verification = await verifyBalances(config.assetId, result.decimals, Array.from(result.completedAddresses));
-      result.verificationSample = verification;
-      if (verification.mismatches.length > 0) {
-        result.syncing = true;
-        result.warnings.push(`Indexer still syncing balances for ${verification.mismatches.length} sampled wallet(s).`);
-      }
-    }
-
-    console.info('[Algoland] Week summary', {
-      week: config.week,
-      assetId: config.assetId || null,
-      completed: result.completedCount,
-      conversion: result.conversion,
-    });
-
-    return result;
-  }
-
-  async function fetchAssetDetails(assetId) {
-    const response = await fetchWithRetry(new URL(`/v2/assets/${assetId}`, providerBase));
-    const asset = response.asset || {};
-    const params = asset.params || {};
-    const decimals = typeof params.decimals === 'number' ? params.decimals : 0;
-    const adminAddresses = new Set();
-    ['creator', 'manager', 'reserve', 'clawback'].forEach((key) => {
-      if (asset[key]) {
-        adminAddresses.add(asset[key]);
-      }
-      if (params[key]) {
-        adminAddresses.add(params[key]);
-      }
-    });
-    return { decimals, adminAddresses };
-  }
-
-  async function verifyBalances(assetId, decimals, addresses) {
-    const pool = [...addresses];
-    for (let i = pool.length - 1; i > 0; i -= 1) {
-      const j = Math.floor(Math.random() * (i + 1));
-      const temp = pool[i];
-      pool[i] = pool[j];
-      pool[j] = temp;
-    }
-    const sample = pool.slice(0, Math.min(3, pool.length));
-    const mismatches = [];
-    const threshold = decimals > 0 ? Math.pow(10, decimals) : 1;
-
-    for (const address of sample) {
-      try {
-        const response = await fetchWithRetry(new URL(`/v2/accounts/${address}`, providerBase));
-        const account = response.account || {};
-        const assets = Array.isArray(account.assets) ? account.assets : [];
-        const holding = assets.find((entry) => String(entry['asset-id']) === String(assetId));
-        const amount = holding ? Number(holding.amount) : 0;
-        if (!holding || Number.isNaN(amount) || amount < threshold) {
-          mismatches.push(address);
-        }
-      } catch (error) {
-        mismatches.push(address);
-      }
-    }
-
-    return { checked: sample, mismatches };
-  }
-
-  async function fetchWithRetry(url, attempt = 0) {
-    const requestUrl = typeof url === 'string' ? url : url.toString();
-    const started = performance.now();
-
-    try {
-      const response = await fetch(requestUrl, {
-        headers: { Accept: 'application/json' },
-        mode: 'cors',
-      });
-
-      if (!response.ok) {
-        if ((response.status === 429 || response.status >= 500) && attempt + 1 < MAX_RETRIES) {
-          const delayMs = Math.pow(2, attempt) * RETRY_BASE_DELAY_MS;
-          await delay(delayMs);
-          return fetchWithRetry(url, attempt + 1);
-        }
-
-        throw new Error(`Indexer request failed with status ${response.status}`);
-      }
-
-      const json = await response.json();
-      const duration = performance.now() - started;
-      console.info(`[Algoland] ${requestUrl} completed in ${duration.toFixed(0)}ms`);
-      return json;
-    } catch (error) {
-      if (attempt + 1 < MAX_RETRIES) {
-        const delayMs = Math.pow(2, attempt) * RETRY_BASE_DELAY_MS;
-        await delay(delayMs);
-        return fetchWithRetry(url, attempt + 1);
-      }
-      throw error;
-    }
-  }
-
-  function delay(ms) {
-    return new Promise((resolve) => window.setTimeout(resolve, ms));
-  }
-
-  function persistSnapshot(snapshot) {
-    try {
-      window.localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(snapshot));
-    } catch (error) {
-      console.warn('[Algoland] Unable to persist snapshot', error);
-    }
-  }
-
   function loadSnapshot() {
     try {
       const raw = window.localStorage.getItem(SNAPSHOT_KEY);
       if (!raw) {
         return null;
       }
-      const parsed = JSON.parse(raw);
-      if (!parsed || !parsed.timestamp) {
-        return null;
-      }
-      return parsed;
+      return JSON.parse(raw);
     } catch (error) {
-      console.warn('[Algoland] Unable to load snapshot', error);
+      console.warn('[Algoland] Failed to read cached snapshot', error);
       return null;
     }
   }
 
-  function trimAllowlistLog(log) {
-    if (!Array.isArray(log)) {
-      return [];
+  function saveSnapshot(snapshot) {
+    try {
+      window.localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(snapshot));
+    } catch (error) {
+      console.warn('[Algoland] Failed to persist snapshot', error);
     }
-    const unique = [];
-    log.forEach((entry) => {
-      if (!entry || typeof entry !== 'object') {
-        return;
-      }
-      const exists = unique.some((item) => item.week === entry.week && item.address === entry.address);
-      if (!exists) {
-        unique.push(entry);
-      }
-    });
-    return unique.slice(-50);
   }
 
-  function renderSnapshot(snapshot, { fromCache, warnings, cacheNotice } = {}) {
-    if (!snapshot || !table) {
+  function createBaseSnapshot(previousSnapshot) {
+    const previous = previousSnapshot || {};
+    const entrants = previous.entrants || { count: null, updatedAt: null, stale: false, source: null };
+    const weeks = weeksConfig.map((config) => {
+      const existing = Array.isArray(previous.weeks)
+        ? previous.weeks.find((week) => week.week === config.week)
+        : null;
+      return {
+        week: config.week,
+        assetId: config.assetId || null,
+        status: config.assetId ? 'live' : 'coming-soon',
+        completions: existing && typeof existing.completions === 'number' ? existing.completions : null,
+        updatedAt: existing ? existing.updatedAt || null : null,
+        stale: Boolean(existing && existing.stale),
+        source: existing ? existing.source || null : null,
+        unavailable: existing ? Boolean(existing.unavailable) : false,
+      };
+    });
+    return {
+      timestamp: new Date().toISOString(),
+      entrants,
+      weeks,
+    };
+  }
+
+  async function refreshData(reason) {
+    if (state.isRefreshing) {
       return;
     }
+    state.isRefreshing = true;
+    console.info('[Algoland] Refreshing data', { reason });
+    if (updatedElement) {
+      updatedElement.textContent = 'Refreshing data…';
+    }
 
-    const entrantsCount = typeof snapshot.entrants?.count === 'number' ? snapshot.entrants.count : 0;
-    setSummaryValue(summaryElements.entrants, entrantsCount);
+    const nextSnapshot = createBaseSnapshot(state.snapshot);
+    const alerts = [];
 
+    try {
+      const entrantsResult = await fetchEntrants();
+      if (entrantsResult) {
+        nextSnapshot.entrants = {
+          count: entrantsResult.entrants,
+          updatedAt: entrantsResult.updatedAt,
+          source: entrantsResult.source || null,
+          stale: Boolean(entrantsResult.stale),
+        };
+        if (entrantsResult.stale) {
+          alerts.push({ type: 'warning', text: 'Entrant totals are stale until the indexer recovers.' });
+        }
+      } else if (!nextSnapshot.entrants || nextSnapshot.entrants.count === null) {
+        alerts.push({ type: 'warning', text: 'Entrant totals are currently unavailable.' });
+      }
+    } catch (error) {
+      console.warn('[Algoland] Failed to fetch entrants', error);
+      if (!nextSnapshot.entrants || nextSnapshot.entrants.count === null) {
+        alerts.push({ type: 'warning', text: 'Entrant totals are currently unavailable.' });
+      } else {
+        nextSnapshot.entrants.stale = true;
+        alerts.push({ type: 'warning', text: 'Entrant totals were served from cache.' });
+      }
+    }
+
+    const liveWeeks = weeksConfig.filter((config) => Boolean(config.assetId));
+    for (const config of liveWeeks) {
+      const weekRecord = nextSnapshot.weeks.find((week) => week.week === config.week);
+      try {
+        const result = await fetchCompletions(config.assetId);
+        if (result) {
+          weekRecord.completions = result.completions;
+          weekRecord.updatedAt = result.updatedAt;
+          weekRecord.source = result.source || null;
+          weekRecord.stale = Boolean(result.stale);
+          weekRecord.unavailable = false;
+          if (result.stale) {
+            alerts.push({ type: 'warning', text: `Week ${config.week} completions are stale until the indexer recovers.` });
+          }
+        } else if (weekRecord.completions === null) {
+          weekRecord.unavailable = true;
+          alerts.push({ type: 'warning', text: `Week ${config.week} completions are currently unavailable.` });
+        } else {
+          weekRecord.stale = true;
+          alerts.push({ type: 'warning', text: `Week ${config.week} completions were served from cache.` });
+        }
+      } catch (error) {
+        console.warn('[Algoland] Failed to fetch completions', { assetId: config.assetId, error });
+        if (typeof weekRecord.completions === 'number') {
+          weekRecord.stale = true;
+          alerts.push({ type: 'warning', text: `Week ${config.week} completions were served from cache.` });
+        } else {
+          weekRecord.unavailable = true;
+          alerts.push({ type: 'warning', text: `Week ${config.week} completions are currently unavailable.` });
+        }
+      }
+    }
+
+    nextSnapshot.timestamp = new Date().toISOString();
+    state.snapshot = nextSnapshot;
+    renderSnapshot(nextSnapshot, { fromCache: false, alerts, reason });
+    saveSnapshot(nextSnapshot);
+    state.isRefreshing = false;
+    console.info('[Algoland] Refresh complete', {
+      entrants: nextSnapshot.entrants?.count,
+      weeks: nextSnapshot.weeks
+        .filter((week) => typeof week.completions === 'number')
+        .map((week) => ({ week: week.week, completions: week.completions, stale: week.stale })),
+    });
+  }
+
+  async function fetchEntrants() {
+    const response = await fetch(buildApiUrl('/api/entrants'), {
+      headers: { accept: 'application/json' },
+      credentials: 'omit',
+    });
+    if (!response.ok) {
+      throw new Error(`Entrants request failed with status ${response.status}`);
+    }
+    const data = await response.json();
+    if (typeof data.entrants !== 'number') {
+      return null;
+    }
+    return data;
+  }
+
+  async function fetchCompletions(assetId) {
+    const url = new URL(buildApiUrl('/api/completions'), window.location.origin);
+    url.searchParams.set('asset', assetId);
+    const response = await fetch(url.toString(), {
+      headers: { accept: 'application/json' },
+      credentials: 'omit',
+    });
+    if (!response.ok) {
+      if (response.status >= 500) {
+        throw new Error(`Completions request failed with status ${response.status}`);
+      }
+      return null;
+    }
+    const data = await response.json();
+    if (typeof data.completions !== 'number') {
+      return null;
+    }
+    return data;
+  }
+
+  function renderSnapshot(snapshot, { fromCache, alerts }) {
+    renderSummary(snapshot);
+    renderTable(snapshot);
+    renderAlerts(alerts, fromCache);
+    renderUpdated(snapshot);
+  }
+
+  function renderSummary(snapshot) {
+    const entrantsCount = typeof snapshot.entrants?.count === 'number' ? snapshot.entrants.count : null;
     const week1 = snapshot.weeks.find((week) => week.week === 1);
     const week2 = snapshot.weeks.find((week) => week.week === 2);
-    setSummaryValue(summaryElements.week1, week1 && typeof week1.completedCount === 'number' ? week1.completedCount : null);
-    setSummaryValue(summaryElements.week2, week2 && typeof week2.completedCount === 'number' ? week2.completedCount : null);
+    const liveWeeks = snapshot.weeks.filter((week) => typeof week.completions === 'number');
+    const overallCompleted = liveWeeks.reduce((total, week) => total + (week.completions || 0), 0);
 
-    const overallCompleted = snapshot.weeks.reduce((total, week) => {
-      if (!week || week.comingSoon || week.allowlistEmpty || typeof week.completedCount !== 'number') {
-        return total;
-      }
-      return total + week.completedCount;
-    }, 0);
-    setSummaryValue(summaryElements.overall, overallCompleted);
+    if (summaryElements.entrants) {
+      summaryElements.entrants.textContent = entrantsCount !== null ? numberFormatter.format(entrantsCount) : '—';
+    }
+    if (summaryElements.week1) {
+      summaryElements.week1.textContent = typeof week1?.completions === 'number' ? numberFormatter.format(week1.completions) : '—';
+    }
+    if (summaryElements.week2) {
+      summaryElements.week2.textContent = typeof week2?.completions === 'number' ? numberFormatter.format(week2.completions) : '—';
+    }
+    if (summaryElements.overall) {
+      summaryElements.overall.textContent = liveWeeks.length > 0 ? numberFormatter.format(overallCompleted) : '—';
+    }
+  }
 
-    snapshot.weeks.forEach((week) => {
-      const row = table.querySelector(`tr[data-week="${week.week}"]`);
+  function renderTable(snapshot) {
+    if (!table) {
+      return;
+    }
+    const entrantsCount = typeof snapshot.entrants?.count === 'number' ? snapshot.entrants.count : null;
+    snapshot.weeks.forEach((weekSnapshot) => {
+      const row = table.querySelector(`tr[data-week="${weekSnapshot.week}"]`);
       if (!row) {
         return;
       }
-
       const entrantsCell = row.querySelector('[data-col="entrants"]');
       if (entrantsCell) {
-        entrantsCell.textContent = numberFormatter.format(entrantsCount);
+        if (entrantsCount !== null) {
+          entrantsCell.textContent = numberFormatter.format(entrantsCount);
+          entrantsCell.classList.remove('na-value');
+        } else {
+          entrantsCell.textContent = '—';
+        }
       }
-
       const completedCell = row.querySelector('[data-col="completed"]');
       const conversionCell = row.querySelector('[data-col="conversion"]');
-
-      if (!week.assetId) {
-        if (completedCell) {
-          completedCell.textContent = 'N/A';
-          completedCell.classList.add('na-value');
-        }
-        if (conversionCell) {
-          conversionCell.textContent = 'N/A';
-          conversionCell.classList.add('na-value');
-        }
-        row.classList.remove('is-syncing');
+      if (!completedCell || !conversionCell) {
         return;
       }
-
-      const note = completedCell ? completedCell.querySelector('.status-note') : null;
-      if (note) {
-        note.remove();
+      if (weekSnapshot.status === 'coming-soon') {
+        completedCell.textContent = 'N/A';
+        completedCell.classList.add('na-value');
+        conversionCell.textContent = 'N/A';
+        conversionCell.classList.add('na-value');
+        return;
       }
-
-      if (completedCell) {
-        if (week.allowlistEmpty || typeof week.completedCount !== 'number') {
-          completedCell.textContent = 'N/A';
-          completedCell.classList.add('na-value');
+      completedCell.classList.remove('na-value');
+      conversionCell.classList.remove('na-value');
+      if (typeof weekSnapshot.completions === 'number') {
+        completedCell.textContent = numberFormatter.format(weekSnapshot.completions);
+        if (entrantsCount && entrantsCount > 0) {
+          const ratio = weekSnapshot.completions / entrantsCount;
+          conversionCell.textContent = percentFormatter.format(ratio);
         } else {
-          completedCell.textContent = numberFormatter.format(week.completedCount);
-          completedCell.classList.remove('na-value');
-        }
-      }
-
-      if (conversionCell) {
-        if (week.allowlistEmpty || typeof week.conversion !== 'number') {
           conversionCell.textContent = 'N/A';
           conversionCell.classList.add('na-value');
-        } else {
-          conversionCell.textContent = percentFormatter.format(week.conversion);
-          conversionCell.classList.remove('na-value');
+        }
+      } else if (weekSnapshot.unavailable) {
+        completedCell.textContent = 'Unavailable';
+        conversionCell.textContent = 'N/A';
+        conversionCell.classList.add('na-value');
+      } else {
+        completedCell.textContent = '—';
+        conversionCell.textContent = entrantsCount ? 'N/A' : '—';
+        if (!entrantsCount) {
+          conversionCell.classList.add('na-value');
         }
       }
-
-      if (completedCell && week.warnings && week.warnings.length > 0) {
-        const statusNote = document.createElement('div');
-        statusNote.className = 'status-note';
-        statusNote.textContent = week.warnings[0];
-        completedCell.appendChild(statusNote);
-      }
-
-      row.classList.toggle('is-syncing', Boolean(week.syncing));
     });
-
-    if (updatedElement) {
-      const timestamp = snapshot.timestamp ? new Date(snapshot.timestamp) : new Date();
-      const parts = [
-        `Last updated ${timestamp.toLocaleString()}`,
-        `Provider: ${snapshot.provider || snapshot.providerUsed || providerBase}`,
-      ];
-      if (fromCache) {
-        parts.push('served from cache');
-      }
-      updatedElement.textContent = parts.join(' • ');
-    }
-
-    const alertMessages = Array.isArray(warnings) ? [...warnings] : [];
-    const timestampValue = snapshot.timestamp ? Date.parse(snapshot.timestamp) : NaN;
-    if (!Number.isNaN(timestampValue)) {
-      const ageMs = Date.now() - timestampValue;
-      if (ageMs > CACHE_MS) {
-        alertMessages.push({
-          type: 'warning',
-          text: 'Snapshot age exceeds 10 minutes. Counts may not include the most recent activity.',
-        });
-      }
-    }
-    snapshot.weeks.forEach((week) => {
-      if (Array.isArray(week.warnings)) {
-        week.warnings.forEach((warning) => {
-          alertMessages.push({ type: 'warning', text: `Week ${week.week}: ${warning}` });
-        });
-      }
-      if (Array.isArray(week.allowlistSuggestions) && week.allowlistSuggestions.length > 0) {
-        week.allowlistSuggestions.forEach((entry) => {
-          alertMessages.push({
-            type: 'info',
-            text: `Week ${week.week}: Observed organiser sender ${shortenAddress(entry.address)} awaiting verification.`,
-          });
-        });
-      }
-    });
-
-    if (cacheNotice) {
-      alertMessages.push({ type: 'info', text: 'Cached results remain valid for 10 minutes. Live refresh will retry automatically.' });
-    }
-
-    renderAlerts(alertMessages);
   }
 
-  function setSummaryValue(element, value) {
-    if (!element) {
-      return;
-    }
-    if (typeof value === 'number') {
-      element.textContent = numberFormatter.format(value);
-    } else {
-      element.textContent = '—';
-    }
-  }
-
-  function renderAlerts(messages) {
+  function renderAlerts(alerts, fromCache) {
     if (!alertsContainer) {
       return;
     }
+    alertsContainer.textContent = '';
+    const uniqueAlerts = [];
+    alerts.forEach((alert) => {
+      if (!alert || !alert.text) {
+        return;
+      }
+      if (!uniqueAlerts.some((item) => item.text === alert.text)) {
+        uniqueAlerts.push(alert);
+      }
+    });
+    if (fromCache && uniqueAlerts.length === 0) {
+      uniqueAlerts.push({ type: 'info', text: 'Showing the last saved snapshot while fresh data loads.' });
+    }
+    uniqueAlerts.forEach((alert) => {
+      const element = document.createElement('div');
+      element.className = 'algoland-alert';
+      if (alert.type === 'info') {
+        element.classList.add('algoland-alert--info');
+      }
+      element.textContent = alert.text;
+      alertsContainer.appendChild(element);
+    });
+  }
 
-    alertsContainer.innerHTML = '';
-
-    const filtered = Array.isArray(messages)
-      ? messages.filter((message) => message && typeof message.text === 'string' && message.text.trim().length > 0)
-      : [];
-
-    if (filtered.length === 0) {
-      alertsContainer.hidden = true;
+  function renderUpdated(snapshot) {
+    if (!updatedElement) {
       return;
     }
-
-    alertsContainer.hidden = false;
-
-    filtered.forEach((message) => {
-      const alert = document.createElement('div');
-      alert.className = 'algoland-alert';
-      if (message.type === 'info') {
-        alert.classList.add('algoland-alert--info');
-      }
-      alert.textContent = message.text;
-      alertsContainer.appendChild(alert);
+    if (!snapshot) {
+      updatedElement.textContent = '';
+      return;
+    }
+    const updatedAt = snapshot.timestamp ? new Date(snapshot.timestamp) : null;
+    if (!updatedAt || Number.isNaN(updatedAt.getTime())) {
+      updatedElement.textContent = '';
+      return;
+    }
+    const formatted = updatedAt.toLocaleString('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      timeZoneName: 'short',
     });
+    const staleLabels = [];
+    if (snapshot.entrants?.stale) {
+      staleLabels.push('entrants');
+    }
+    snapshot.weeks.forEach((week) => {
+      if (week.stale) {
+        staleLabels.push(`week ${week.week}`);
+      }
+    });
+    if (staleLabels.length > 0) {
+      updatedElement.textContent = `Last updated ${formatted} (stale: ${staleLabels.join(', ')})`;
+    } else {
+      updatedElement.textContent = `Last updated ${formatted}`;
+    }
   }
 })();

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,38 @@
+# Algoland backend API
+
+This directory contains a small Express service that proxies Algorand Indexer queries on behalf of the public Algoland dashboard. It exposes cached endpoints that the static site can call without shipping any credentials or provider URLs to browsers.
+
+## Endpoints
+
+- `GET /api/ping` — health check that reports configuration basics.
+- `GET /api/entrants` — total entrant wallets with local state for application `3215540125`.
+- `GET /api/completions?asset=<assetId>` — unique receivers of positive badge transfers for a given ASA.
+
+All responses are cached in-memory for five minutes by default. When the upstream Indexer is unavailable the service falls back to the last cached payload and marks it as `stale: true`.
+
+## Local development
+
+```bash
+cd backend
+npm install
+npm run dev
+```
+
+The service listens on `http://localhost:3000` by default. Configure the following environment variables as needed:
+
+- `ALLOWED_ORIGINS` — comma-separated list of origins permitted to access the API. Example: `https://emnetcm.com,https://www.emnetcm.com`.
+- `INDEXER_BASE` — Algorand Indexer base URL. Defaults to `https://mainnet-idx.algonode.cloud`.
+- `CACHE_TTL_SECONDS` — overrides the default 300 second cache TTL.
+- `INDEXER_MAX_RETRIES` and `INDEXER_RETRY_BASE_MS` — adjust retry behaviour when the Indexer returns 429 or 5xx responses.
+
+## Deployment on Render
+
+1. Create a new Web Service from this directory.
+2. Set the build command to `npm install` and the start command to `npm start`.
+3. Configure the environment variables listed above.
+4. After deployment succeeds, verify:
+   - `/api/ping` responds with service metadata.
+   - `/api/entrants` returns the entrants count and timestamp.
+   - `/api/completions?asset=3215542831` returns the completions count for week 1.
+
+Remember to update the static site configuration so `/algoland` fetches data from the deployed Render URL.

--- a/backend/config.js
+++ b/backend/config.js
@@ -1,0 +1,39 @@
+export const APP_ID = 3215540125;
+
+export const WEEK_CONFIG = [
+  { week: 1, assetId: 3215542831 },
+  { week: 2, assetId: 3215542840 },
+  { week: 3, assetId: null },
+  { week: 4, assetId: null },
+  { week: 5, assetId: null },
+  { week: 6, assetId: null },
+  { week: 7, assetId: null },
+  { week: 8, assetId: null },
+  { week: 9, assetId: null },
+  { week: 10, assetId: null },
+  { week: 11, assetId: null },
+  { week: 12, assetId: null },
+  { week: 13, assetId: null },
+];
+
+const DEFAULT_DISTRIBUTOR = 'HHADCZKQV24QDCBER5GTOH7BOLF4ZQ6WICNHAA3GZUECIMJXIIMYBIWEZM';
+
+export const DISTRIBUTOR_ALLOWLIST = {
+  default: [DEFAULT_DISTRIBUTOR],
+  byAsset: {
+    3215542831: [DEFAULT_DISTRIBUTOR],
+    3215542840: [DEFAULT_DISTRIBUTOR],
+  },
+};
+
+export function getAllowlistForAsset(assetId) {
+  if (!assetId) {
+    return DISTRIBUTOR_ALLOWLIST.default;
+  }
+  const key = String(assetId);
+  const list = DISTRIBUTOR_ALLOWLIST.byAsset[key];
+  if (Array.isArray(list) && list.length > 0) {
+    return list;
+  }
+  return DISTRIBUTOR_ALLOWLIST.default;
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,365 @@
+import cors from 'cors';
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import NodeCache from 'node-cache';
+import { performance } from 'node:perf_hooks';
+
+import { APP_ID, DISTRIBUTOR_ALLOWLIST, WEEK_CONFIG, getAllowlistForAsset } from './config.js';
+
+const app = express();
+app.disable('x-powered-by');
+app.set('trust proxy', 1);
+
+const PORT = process.env.PORT || 3000;
+const RAW_ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS || 'https://emnetcm.com,https://www.emnetcm.com';
+const INDEXER_BASE = (process.env.INDEXER_BASE || 'https://mainnet-idx.algonode.cloud').replace(/\/+$/, '');
+const CACHE_TTL_SECONDS = Number.parseInt(process.env.CACHE_TTL_SECONDS || '', 10) || 300;
+const MAX_RETRIES = Number.parseInt(process.env.INDEXER_MAX_RETRIES || '', 10) || 5;
+const RETRY_BASE_DELAY_MS = Number.parseInt(process.env.INDEXER_RETRY_BASE_MS || '', 10) || 500;
+
+const allowedOrigins = RAW_ALLOWED_ORIGINS.split(',')
+  .map((origin) => origin.trim())
+  .filter((origin) => origin.length > 0);
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin) {
+      callback(null, true);
+      return;
+    }
+    if (allowedOrigins.length === 0 || allowedOrigins.includes(origin)) {
+      callback(null, true);
+      return;
+    }
+    callback(new Error('Not allowed by CORS'), false);
+  },
+  methods: ['GET', 'OPTIONS'],
+  optionsSuccessStatus: 204,
+};
+
+app.use(cors(corsOptions));
+app.options('*', cors(corsOptions));
+
+const limiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+app.use(limiter);
+
+const responseCache = new NodeCache({
+  stdTTL: CACHE_TTL_SECONDS,
+  checkperiod: Math.max(Math.floor(CACHE_TTL_SECONDS / 2), 30),
+  useClones: false,
+});
+
+const assetMetadataCache = new NodeCache({
+  stdTTL: 6 * 60 * 60,
+  checkperiod: 60 * 60,
+  useClones: false,
+});
+
+function normalisePath(path) {
+  if (!path.startsWith('/')) {
+    return `/${path}`;
+  }
+  return path;
+}
+
+async function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function indexerRequest(path, params = {}) {
+  const url = new URL(normalisePath(path), `${INDEXER_BASE}`);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') {
+      return;
+    }
+    url.searchParams.set(key, value);
+  });
+
+  let attempt = 0;
+  let delayMs = RETRY_BASE_DELAY_MS;
+  let lastError;
+  while (attempt < MAX_RETRIES) {
+    try {
+      const start = performance.now();
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+        },
+      });
+      const durationMs = performance.now() - start;
+      if (response.status === 429 || response.status >= 500) {
+        lastError = new Error(`Indexer responded with status ${response.status}`);
+        console.warn('[Algoland API] Indexer busy', {
+          url: url.toString(),
+          status: response.status,
+          attempt: attempt + 1,
+          durationMs,
+        });
+      } else if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Indexer request failed (${response.status}): ${errorText}`);
+      } else {
+        console.info('[Algoland API] Indexer request complete', {
+          url: url.toString(),
+          status: response.status,
+          durationMs,
+          attempt: attempt + 1,
+        });
+        return response.json();
+      }
+    } catch (error) {
+      lastError = error;
+      console.warn('[Algoland API] Indexer request error', {
+        url: url.toString(),
+        attempt: attempt + 1,
+        message: error.message,
+      });
+    }
+    attempt += 1;
+    if (attempt < MAX_RETRIES) {
+      await delay(delayMs);
+      delayMs *= 2;
+    }
+  }
+  throw lastError || new Error('Indexer request failed');
+}
+
+async function getEntrantsCount() {
+  const cacheKey = 'entrants';
+  const cached = responseCache.get(cacheKey);
+  try {
+    const start = performance.now();
+    let nextToken;
+    let pageCount = 0;
+    let totalAccounts = 0;
+    do {
+      const params = {
+        'application-id': APP_ID,
+        limit: 1000,
+      };
+      if (nextToken) {
+        params.next = nextToken;
+      }
+      const page = await indexerRequest('/v2/accounts', params);
+      pageCount += 1;
+      const accounts = Array.isArray(page.accounts) ? page.accounts : [];
+      totalAccounts += accounts.length;
+      nextToken = page['next-token'] || null;
+    } while (nextToken);
+    const durationMs = performance.now() - start;
+    const payload = {
+      entrants: totalAccounts,
+      updatedAt: new Date().toISOString(),
+      source: INDEXER_BASE,
+      meta: { pageCount, durationMs },
+    };
+    responseCache.set(cacheKey, payload);
+    console.info('[Algoland API] Entrants computed', {
+      entrants: totalAccounts,
+      pageCount,
+      durationMs,
+    });
+    return payload;
+  } catch (error) {
+    if (cached) {
+      console.warn('[Algoland API] Entrants falling back to cache', {
+        message: error.message,
+      });
+      return { ...cached, stale: true };
+    }
+    throw error;
+  }
+}
+
+async function getAssetMetadata(assetId) {
+  const cacheKey = `asset:${assetId}`;
+  const cached = assetMetadataCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const asset = await indexerRequest(`/v2/assets/${assetId}`);
+  const params = asset?.asset?.params || {};
+  const adminAddresses = new Set([
+    params.creator,
+    params.manager,
+    params.reserve,
+    params.freeze,
+    params.clawback,
+  ].filter(Boolean));
+  const metadata = {
+    decimals: Number.parseInt(params.decimals, 10) || 0,
+    adminAddresses,
+  };
+  assetMetadataCache.set(cacheKey, metadata, 24 * 60 * 60);
+  return metadata;
+}
+
+function normaliseAmount(amount, decimals) {
+  if (!Number.isFinite(amount)) {
+    return 0;
+  }
+  if (!Number.isFinite(decimals) || decimals <= 0) {
+    return amount;
+  }
+  const divisor = 10 ** decimals;
+  return amount / divisor;
+}
+
+async function getCompletionsForAsset(assetId) {
+  const cacheKey = `completions:${assetId}`;
+  const cached = responseCache.get(cacheKey);
+  try {
+    const allowlist = new Set(getAllowlistForAsset(assetId));
+    const { decimals, adminAddresses } = await getAssetMetadata(assetId);
+    const receivers = new Set();
+    let nextToken;
+    let pageCount = 0;
+    const start = performance.now();
+    do {
+      const params = {
+        limit: 1000,
+        'tx-type': 'axfer',
+      };
+      if (nextToken) {
+        params.next = nextToken;
+      }
+      const data = await indexerRequest(`/v2/assets/${assetId}/transactions`, params);
+      pageCount += 1;
+      const transactions = Array.isArray(data.transactions) ? data.transactions : [];
+      transactions.forEach((txn) => {
+        const transfer = txn['asset-transfer-transaction'];
+        if (!transfer) {
+          return;
+        }
+        const rawAmount = Number(transfer.amount) || 0;
+        const amount = normaliseAmount(rawAmount, decimals);
+        if (amount <= 0) {
+          return;
+        }
+        const txnSender = txn.sender;
+        const assetSender = transfer.sender || txnSender;
+        if (!allowlist.has(txnSender) && !allowlist.has(assetSender)) {
+          return;
+        }
+        const receiver = transfer.receiver;
+        if (!receiver || adminAddresses.has(receiver)) {
+          return;
+        }
+        receivers.add(receiver);
+      });
+      nextToken = data['next-token'] || null;
+    } while (nextToken);
+    const durationMs = performance.now() - start;
+    const payload = {
+      assetId: Number.parseInt(assetId, 10),
+      completions: receivers.size,
+      updatedAt: new Date().toISOString(),
+      source: INDEXER_BASE,
+      meta: { pageCount, durationMs },
+    };
+    responseCache.set(cacheKey, payload);
+    console.info('[Algoland API] Completions computed', {
+      assetId,
+      completions: receivers.size,
+      pageCount,
+      durationMs,
+    });
+    return payload;
+  } catch (error) {
+    if (cached) {
+      console.warn('[Algoland API] Completions falling back to cache', {
+        assetId,
+        message: error.message,
+      });
+      return { ...cached, stale: true };
+    }
+    throw error;
+  }
+}
+
+function sendCachedOrError(res, error) {
+  console.error('[Algoland API] Request failed', { message: error.message });
+  res.status(502).json({
+    error: 'upstream_unavailable',
+    message: 'Indexer is temporarily unavailable. Please retry shortly.',
+  });
+}
+
+app.get('/api/ping', (req, res) => {
+  res.set('Cache-Control', 'no-store');
+  res.json({
+    ok: true,
+    service: 'algoland-backend',
+    provider: INDEXER_BASE,
+    cacheTtlSeconds: CACHE_TTL_SECONDS,
+    now: new Date().toISOString(),
+    configuredOrigins: allowedOrigins,
+    weeks: WEEK_CONFIG,
+    allowlist: DISTRIBUTOR_ALLOWLIST,
+  });
+});
+
+app.get('/api/entrants', async (req, res) => {
+  res.set('Cache-Control', 'no-store');
+  try {
+    const payload = await getEntrantsCount();
+    const responseBody = {
+      entrants: payload.entrants,
+      updatedAt: payload.updatedAt,
+      source: payload.source,
+    };
+    if (payload.stale) {
+      responseBody.stale = true;
+    }
+    res.json(responseBody);
+  } catch (error) {
+    sendCachedOrError(res, error);
+  }
+});
+
+app.get('/api/completions', async (req, res) => {
+  res.set('Cache-Control', 'no-store');
+  const assetId = req.query.asset;
+  if (!assetId) {
+    res.status(400).json({ error: 'missing_asset', message: 'asset query parameter is required' });
+    return;
+  }
+  if (!/^\d+$/.test(String(assetId))) {
+    res.status(400).json({ error: 'invalid_asset', message: 'asset must be a numeric ID' });
+    return;
+  }
+  try {
+    const payload = await getCompletionsForAsset(Number(assetId));
+    const responseBody = {
+      assetId: payload.assetId,
+      completions: payload.completions,
+      updatedAt: payload.updatedAt,
+      source: payload.source,
+    };
+    if (payload.stale) {
+      responseBody.stale = true;
+    }
+    res.json(responseBody);
+  } catch (error) {
+    sendCachedOrError(res, error);
+  }
+});
+
+app.use((req, res) => {
+  res.status(404).json({ error: 'not_found' });
+});
+
+app.listen(PORT, () => {
+  console.info(`[Algoland API] Service listening on port ${PORT}`, {
+    indexerBase: INDEXER_BASE,
+    cacheTtlSeconds: CACHE_TTL_SECONDS,
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "algoland-backend",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node --watch index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "express-rate-limit": "^7.3.0",
+    "node-cache": "^5.1.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add an Express-based backend under `backend/` that proxies the Algorand Indexer with retries, caching, CORS, and rate limiting
- document deployment steps for the new service and ignore backend dependencies in version control
- update the Algoland dashboard script to read counts from the backend, keep the existing UI, and surface stale/unavailable states while preserving cached snapshots
- adjust the Algoland page CSP/connect-src directives and README guidance to target the new API base

## Testing
- node --check backend/index.js
- node --check assets/algoland.js

------
https://chatgpt.com/codex/tasks/task_e_68df0566c8908322af9c3715af48c68d