### PR TITLE
Scan inner badge transfers for completions

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -1,4 +1,6 @@
-export const APP_ID = 3215540125;
+const RAW_APP_ID = process.env.ALGOLAND_APP_ID || '3215540125';
+const PARSED_APP_ID = Number.parseInt(RAW_APP_ID, 10);
+export const APP_ID = Number.isFinite(PARSED_APP_ID) ? PARSED_APP_ID : 3215540125;
 
 export const WEEK_CONFIG = [
   { week: 1, assetId: 3215542831 },


### PR DESCRIPTION
## Summary
- make the campaign app id configurable through the ALGOLAND_APP_ID environment variable
- extend completion counting to include inner asset transfers from the campaign application while deduplicating receivers and honouring the sender allowlist
- collect admin metadata for filtering, apply pagination hints, and log detailed scan metrics for each completion query

## Testing
- node --check backend/index.js

------
https://chatgpt.com/codex/tasks/task_e_68df113e01148322bce66640244e8adb