### PR TITLE
Point Algoland dashboard to Render API

### DIFF
--- a/algoland.html
+++ b/algoland.html
@@ -80,7 +80,7 @@
     </div>
   </header>
 
-  <main data-algoland-root data-api-base="https://api.emnetcm.com">
+  <main data-algoland-root data-api-base="https://algoland-api.onrender.com">
     <section class="container section algoland-hero">
       <h1>Algoland progress</h1>
       <p class="section-lede">Live on chain counts of challenge entrants and badge completions.</p>


### PR DESCRIPTION
## Summary
- point the Algoland progress page at the Render-hosted API base so live data loads correctly

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df18ecb53c832297b98f907ec55b2a