### PR TITLE
Update Algoland hero styling and week status messaging

### DIFF
--- a/algoland.html
+++ b/algoland.html
@@ -83,13 +83,14 @@
   <main data-algoland-root data-api-base="https://algoland-api.onrender.com">
     <section class="algoland-hero">
       <div class="algoland-hero__inner container">
-        <h1>Algoland - Competition tracker</h1>
-        <p class="section-lede">Have you joined algoland yet? The Algorand foundations 13 weeks of on-chain action. Prizes to be won every week and there are grand prizes too!</p>
-        <p>Track your competition below with a live counter of how many have joined the party and how many have completed each quest.</p>
-        <p>To join the fun just click the button below and come join in!</p>
-        <div class="cta-actions">
-          <a class="btn" href="https://www.algoland.co/?referralCode=107" target="_blank" rel="noopener">Join now</a>
-          <a class="btn" href="https://www.algoland.co/info" target="_blank" rel="noopener">Learn more</a>
+        <div class="algoland-hero__copy">
+          <h1>Algoland - Competition tracker</h1>
+          <p class="section-lede">Have you joined algoland yet? The Algorand foundations 13 weeks of on-chain action. Prizes to be won every week and there are grand prizes too! Track your competition below with a live counter of how many have joined the party and how many have completed each quest.</p>
+          <p>To join the fun just click the button below and come join in!</p>
+          <div class="cta-actions">
+            <a class="btn" href="https://www.algoland.co/?referralCode=107" target="_blank" rel="noopener">Join now</a>
+            <a class="btn" href="https://www.algoland.co/info" target="_blank" rel="noopener">Learn more</a>
+          </div>
         </div>
       </div>
     </section>

--- a/assets/algoland.js
+++ b/assets/algoland.js
@@ -7,6 +7,7 @@
   const API_BASE = normaliseBase(root.dataset.apiBase || window.EMNET_ALGOLAND_API_BASE || '');
   const SNAPSHOT_KEY = 'emnet.algoland.snapshot.v2';
   const REFRESH_INTERVAL_MS = 10 * 60 * 1000;
+  const ONE_WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
   const DEFAULT_DISTRIBUTOR = 'HHADCZKQV24QDCBER5GTOH7BOLF4ZQ6WICNHAA3GZUECIMJXIIMYBIWEZM';
   const APP_ID = 3215540125;
 
@@ -369,7 +370,10 @@
       card.card.classList.toggle('is-upcoming', !isOpen);
 
       if (card.statusElement) {
-        if (isOpen) {
+        const openedForMs = opensOn ? now - opensOn : 0;
+        if (isOpen && openedForMs >= ONE_WEEK_IN_MS) {
+          card.statusElement.textContent = 'Catch up';
+        } else if (isOpen) {
           card.statusElement.textContent = weekSnapshot.status === 'coming-soon' ? 'Open this week' : 'Open now';
         } else if (opensOn) {
           card.statusElement.textContent = `Opens ${formatOpenDate(opensOn)}`;

--- a/styles/main.css
+++ b/styles/main.css
@@ -1129,6 +1129,20 @@ body.about-page .hero-logo {
   gap: clamp(16px, 3vw, 28px);
 }
 
+.algoland-hero__copy {
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 24px;
+  padding: clamp(24px, 4vw, 36px);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.4);
+  display: grid;
+  gap: clamp(16px, 3vw, 24px);
+}
+
+.algoland-hero__copy .cta-actions {
+  justify-content: flex-start;
+}
+
 .algoland-page .section-lede {
   font-size: 1.1rem;
   color: rgba(240, 240, 240, 0.9);


### PR DESCRIPTION
## Summary
- merge the Algoland hero introduction copy into a single paragraph and wrap it in a dedicated container
- add translucent styling so the hero text is easier to read against the background
- update week status logic to show "Catch up" once a challenge has been open for more than a week

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df8e36aa4c83228276ae6e7e748ae4