### PR TITLE
Enhance Algoland tracker with badge rollovers and week 3 update

### DIFF
--- a/algoland.html
+++ b/algoland.html
@@ -114,7 +114,7 @@
     <section class="container section algoland-calendar" aria-live="polite">
       <h2 class="algoland-calendar__title">Weekly challenge tracker</h2>
       <div class="weeks-grid">
-        <article class="week-card is-open" data-week-card data-week="1" data-opens-on="2025-09-22">
+        <article class="week-card is-open has-rollover" data-week-card data-week="1" data-opens-on="2025-09-22">
           <div class="week-card__header">
             <h3>Week 1</h3>
             <p class="week-card__status" data-week-status>Open now</p>
@@ -126,7 +126,7 @@
           <p class="week-card__badge">Badge ASA <span data-week-badge>3215542831</span></p>
           <p class="week-card__opens" data-week-open-text>Opened 22 September 2025</p>
         </article>
-        <article class="week-card is-open" data-week-card data-week="2" data-opens-on="2025-09-29">
+        <article class="week-card is-open has-rollover" data-week-card data-week="2" data-opens-on="2025-09-29">
           <div class="week-card__header">
             <h3>Week 2</h3>
             <p class="week-card__status" data-week-status>Open now</p>
@@ -141,13 +141,13 @@
         <article class="week-card" data-week-card data-week="3" data-opens-on="2025-10-06">
           <div class="week-card__header">
             <h3>Week 3</h3>
-            <p class="week-card__status" data-week-status>Opens Monday 6 October</p>
+            <p class="week-card__status" data-week-status>Ready for Coming Monday</p>
           </div>
           <p class="week-card__count">
             <span class="week-card__count-number" data-week-completions>—</span>
             <span class="week-card__count-label">badges claimed</span>
           </p>
-          <p class="week-card__badge">Badge ASA <span data-week-badge>Coming soon</span></p>
+          <p class="week-card__badge">Badge ASA <span data-week-badge>3215542836</span></p>
           <p class="week-card__opens" data-week-open-text>Opens Monday 6 October 2025</p>
         </article>
         <article class="week-card" data-week-card data-week="4" data-opens-on="2025-10-13">
@@ -314,7 +314,7 @@
             </tr>
             <tr data-week="3">
               <th scope="row">Week 3</th>
-              <td data-col="badge" class="is-hidden-column">Coming soon</td>
+              <td data-col="badge" class="is-hidden-column">3215542836</td>
               <td data-col="distributor" data-distributor-index="0" class="is-hidden-column"></td>
               <td data-col="entrants" title="Wallets opted in to application 3215540125." class="is-hidden-column">—</td>
               <td data-col="completed">N/A</td>

--- a/assets/algoland.js
+++ b/assets/algoland.js
@@ -366,15 +366,20 @@
       const opensOn = card.opensOn;
       const manualOpen = card.defaultIsOpen;
       const isOpen = opensOn ? now >= opensOn || manualOpen : manualOpen;
+      const openedForMs = opensOn ? now - opensOn : 0;
+      const isCatchUp = isOpen && openedForMs >= ONE_WEEK_IN_MS;
       card.card.classList.toggle('is-open', isOpen);
       card.card.classList.toggle('is-upcoming', !isOpen);
+      card.card.classList.toggle('is-catchup', isCatchUp);
 
       if (card.statusElement) {
-        const openedForMs = opensOn ? now - opensOn : 0;
-        if (isOpen && openedForMs >= ONE_WEEK_IN_MS) {
+        card.statusElement.classList.toggle('is-catchup', isCatchUp);
+        if (isCatchUp) {
           card.statusElement.textContent = 'Catch up';
         } else if (isOpen) {
           card.statusElement.textContent = weekSnapshot.status === 'coming-soon' ? 'Open this week' : 'Open now';
+        } else if (weekSnapshot.assetId && opensOn) {
+          card.statusElement.textContent = 'Ready for Coming Monday';
         } else if (opensOn) {
           card.statusElement.textContent = `Opens ${formatOpenDate(opensOn)}`;
         } else {

--- a/styles/main.css
+++ b/styles/main.css
@@ -1234,6 +1234,42 @@ body.about-page .hero-logo {
   transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
+.algoland-page .week-card.has-rollover {
+  overflow: hidden;
+}
+
+.algoland-page .week-card.has-rollover::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background-position: center;
+  background-size: cover;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  z-index: 0;
+}
+
+.algoland-page .week-card.has-rollover > * {
+  position: relative;
+  z-index: 1;
+}
+
+.algoland-page .week-card.has-rollover.is-open:hover::before,
+.algoland-page .week-card.has-rollover.is-open:focus-within::before,
+.algoland-page .week-card.has-rollover.is-catchup:hover::before,
+.algoland-page .week-card.has-rollover.is-catchup:focus-within::before {
+  opacity: 1;
+}
+
+.algoland-page .week-card.has-rollover[data-week="1"]::before {
+  background-image: linear-gradient(180deg, rgba(8, 8, 8, 0.6), rgba(8, 8, 8, 0.85)), url('../assets/week1.png');
+}
+
+.algoland-page .week-card.has-rollover[data-week="2"]::before {
+  background-image: linear-gradient(180deg, rgba(8, 8, 8, 0.6), rgba(8, 8, 8, 0.85)), url('../assets/week2.png');
+}
+
 .algoland-page .week-card.is-open {
   background: rgba(25, 25, 25, 0.9);
   border-color: rgba(38, 211, 197, 0.4);
@@ -1270,6 +1306,10 @@ body.about-page .hero-logo {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: rgba(83, 240, 227, 0.9);
+}
+
+.algoland-page .week-card__status.is-catchup {
+  color: #ffd85e;
 }
 
 .algoland-page .week-card:not(.is-open) .week-card__status {


### PR DESCRIPTION
## Summary
- add rollover badge imagery for open weeks in the Algoland challenge tracker
- highlight catch up status in yellow and expose catch-up state to the DOM
- surface the Week 3 ASA ID and copy for the coming Monday launch in both the card and table

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df93fe22dc832284974eadb0b27d5d