### PR TITLE
Replace homepage craft image with stylized text

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
           <div class="container">
             <img src="assets/logo.png" alt="EmNet logo" class="hero-logo" width="1024" height="1024" decoding="async">
             <h1>EmNet Community Management Ltd</h1>
-            <img src="assets/craft.png" alt="Community is our craft" class="hero-subheading-image" width="1632" height="132" decoding="async">
+            <p class="hero-subheading-text">Community is our Craft</p>
             <p>We design and manage trusted spaces across Web2, Web3, and emerging platforms. At EmNet, it&rsquo;s not just about numbers—it&rsquo;s about creating environments where people choose to stay.</p>
             <p>Serving <a class="link-teal" href="https://www.algorand.foundation/" target="_blank" rel="noopener">Algorand</a> and the wider blockchain community since 2021</p>
             <a class="btn" href="contact.html">Get in touch</a>

--- a/styles/main.css
+++ b/styles/main.css
@@ -337,12 +337,13 @@ body.about-page .hero-logo {
   color: #bbbbbb;
 }
 
-.hero-subheading-image {
-  display: block;
-  max-width: min(100%, 520px);
-  width: 100%;
-  height: auto;
-  margin: 0 auto 18px;
+.hero-subheading-text {
+  margin: 12px auto;
+  font-size: clamp(32px, calc(4vw + 12px), 52px);
+  font-style: italic;
+  font-weight: 500;
+  color: #ff2ebd;
+  text-align: center;
 }
 
 .hero-strapline {


### PR DESCRIPTION
## Summary
- replace the craft hero image with an italic hero tagline reading "Community is our Craft"
- add styling for the new tagline to match the hero heading size and site color palette

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dfb6b3f9888322a01f316c0299a4ac