### PR TITLE
Adjust homepage spacing around hero divider

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -415,14 +415,14 @@ body.about-page .hero-logo {
 
 .hero-divider {
   width: min(100%, 220px);
-  margin: 16px 0;
+  margin: clamp(32px, 6vw, 56px) 0;
   border: 0;
   border-top: 1px solid rgba(255, 255, 255, 0.3);
 }
 
 /* Sections */
 .section {
-  padding: clamp(48px, 11vw, 84px) 0;
+  padding: clamp(64px, 12vw, 120px) 0;
 }
 
 .section h2 {


### PR DESCRIPTION
## Summary
- increase the hero divider margin to add clear space above and below the Get in touch button
- expand default section padding to open up the vertical rhythm across the homepage

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dfc8dcd3dc8322a01aa97a9d03454e