### PR TITLE
Enhance homepage spacing and dividers

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     }
   </script>
 </head>
-<body>
+<body class="home-page">
   <header class="site-header">
     <div class="container header-inner">
       <a href="index.html" class="logo-link" aria-label="EmNet home">
@@ -82,7 +82,7 @@
             <p>We design and manage trusted spaces across Web2, Web3, and emerging platforms. At EmNet, it&rsquo;s not just about numbers—it&rsquo;s about creating environments where people choose to stay.</p>
             <p>Serving <a class="link-teal" href="https://www.algorand.foundation/" target="_blank" rel="noopener">Algorand</a> and the wider blockchain community since 2021</p>
             <a class="btn" href="contact.html">Get in touch</a>
-            <hr class="hero-divider" aria-hidden="true">
+            <img src="assets/divider.png" alt="" class="hero-divider" aria-hidden="true" width="1024" height="341" decoding="async">
           </div>
         </div>
       </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -414,15 +414,31 @@ body.about-page .hero-logo {
 }
 
 .hero-divider {
+  display: block;
   width: min(100%, 220px);
-  margin: clamp(32px, 6vw, 56px) 0;
-  border: 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.3);
+  margin: clamp(32px, 6vw, 56px) auto;
+  height: auto;
 }
 
 /* Sections */
 .section {
   padding: clamp(64px, 12vw, 120px) 0;
+}
+
+.home-page .hero-home {
+  padding-bottom: clamp(96px, 14vw, 160px);
+  border-bottom: 1px solid #222;
+}
+
+.home-page .section {
+  padding: clamp(88px, 14vw, 160px) 0;
+  border-top: 1px solid #222;
+  border-bottom: 1px solid #222;
+}
+
+.home-page .hero-home + .section,
+.home-page .section + .section {
+  margin-top: -1px;
 }
 
 .section h2 {


### PR DESCRIPTION
## Summary
- add a homepage body class to target layout refinements without affecting other pages
- increase section padding and introduce top and bottom borders for clearer separation on the homepage
- swap the hero divider line for the divider image asset to align with branding

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfcc4552588322b9c40dd929ac5351