### PR TITLE
Adjust home hero logo placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
         <img src="assets/Home.jpg" alt="Community operations imagery for EmNet" class="hero-banner-image" width="1536" height="1024" decoding="async">
         <div class="hero-banner-content">
           <div class="container">
-            <img src="assets/logo.png" alt="EmNet logo" class="hero-logo" width="1024" height="1024" decoding="async">
+            <img src="assets/logo.png" alt="EmNet logo" class="hero-logo" width="512" height="512" decoding="async">
             <h1>EmNet Community Management Ltd</h1>
             <p>We design and manage trusted spaces across Web2, Web3, and emerging platforms. At EmNet, it&rsquo;s not just about numbers—it&rsquo;s about creating environments where people choose to stay.</p>
             <p>Serving <a class="link-teal" href="https://www.algorand.foundation/" target="_blank" rel="noopener">Algorand</a> and the wider blockchain community since 2021</p>

--- a/styles/main.css
+++ b/styles/main.css
@@ -82,6 +82,10 @@ body {
   height: var(--header-logo-height);
 }
 
+.home-page .site-header .logo-link {
+  display: none;
+}
+
 .nav {
   display: flex;
   align-items: center;
@@ -313,8 +317,8 @@ body {
 
 .hero-logo {
   display: block;
-  margin: clamp(48px, 10vw, 96px) auto 28px;
-  width: clamp(100px, 28vw, 208px);
+  margin: clamp(32px, 8vw, 64px) auto 20px;
+  width: clamp(88px, 18vw, 160px);
   height: auto;
 }
 


### PR DESCRIPTION
## Summary
- hide the header logo on the home page so branding sits inside the hero banner
- reduce the hero logo dimensions to better fit the banner imagery

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dfd2b8d45883229e22adf27b596834