### PR TITLE
Scale navbar logo height

### DIFF
--- a/about.html
+++ b/about.html
@@ -53,6 +53,7 @@
     <div class="container header-inner">
       <a href="index.html" class="logo-link" aria-label="EmNet home">
         <img src="assets/logo.png" alt="EmNet logo" class="logo" width="1024" height="1024" decoding="async">
+        <span class="logo-text">EmNet</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Toggle navigation</span>

--- a/algoland.html
+++ b/algoland.html
@@ -62,6 +62,7 @@
     <div class="container header-inner">
       <a href="index.html" class="logo-link" aria-label="EmNet home">
         <img src="assets/logo.png" alt="EmNet logo" class="logo" width="1024" height="1024" decoding="async">
+        <span class="logo-text">EmNet</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Toggle navigation</span>

--- a/contact.html
+++ b/contact.html
@@ -55,6 +55,7 @@
     <div class="container header-inner">
       <a href="index.html" class="logo-link" aria-label="EmNet home">
         <img src="assets/logo.png" alt="EmNet logo" class="logo" width="1024" height="1024" decoding="async">
+        <span class="logo-text">EmNet</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Toggle navigation</span>

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -75,6 +75,7 @@
     <div class="container header-inner">
       <a href="index.html" class="logo-link" aria-label="EmNet home">
         <img src="assets/logo.png" alt="EmNet logo" class="logo" width="1024" height="1024" decoding="async">
+        <span class="logo-text">EmNet</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Toggle navigation</span>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
     <div class="container header-inner">
       <a href="index.html" class="logo-link" aria-label="EmNet home">
         <img src="assets/logo.png" alt="EmNet logo" class="logo" width="1024" height="1024" decoding="async">
+        <span class="logo-text">EmNet</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Toggle navigation</span>

--- a/privacy.html
+++ b/privacy.html
@@ -45,6 +45,7 @@
     <div class="container header-inner">
       <a href="index.html" class="logo-link" aria-label="EmNet home">
         <img src="assets/logo.png" alt="EmNet logo" class="logo" width="1024" height="1024" decoding="async">
+        <span class="logo-text">EmNet</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Toggle navigation</span>

--- a/services.html
+++ b/services.html
@@ -59,6 +59,7 @@
     <div class="container header-inner">
       <a href="index.html" class="logo-link" aria-label="EmNet home">
         <img src="assets/logo.png" alt="EmNet logo" class="logo" width="1024" height="1024" decoding="async">
+        <span class="logo-text">EmNet</span>
       </a>
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">
         <span class="sr-only">Toggle navigation</span>

--- a/styles/main.css
+++ b/styles/main.css
@@ -4,8 +4,8 @@
 }
 
 :root {
-  --header-logo-height: clamp(16px, 2.5vw, 20px);
-  --header-vertical-padding: clamp(18px, 3vw, 28px);
+  --header-logo-height: clamp(40px, 6vw, 64px);
+  --header-vertical-padding: clamp(12px, 2.5vw, 20px);
   --site-header-height: calc(var(--header-logo-height) + (var(--header-vertical-padding) * 2));
   --cookie-banner-height: 0px;
 }
@@ -64,7 +64,6 @@ body {
 .header-inner {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 16px;
   min-height: var(--site-header-height);
   padding: var(--header-vertical-padding) 0;
@@ -74,6 +73,9 @@ body {
 .logo-link {
   display: inline-flex;
   align-items: center;
+  gap: 12px;
+  color: #f0f0f0;
+  text-decoration: none;
 }
 
 .logo {
@@ -82,13 +84,20 @@ body {
   height: var(--header-logo-height);
 }
 
+.logo-text {
+  font-weight: 600;
+}
+
 .home-page .site-header .logo-link {
-  display: none;
+  display: inline-flex;
 }
 
 .nav {
   display: flex;
   align-items: center;
+  margin-left: auto;
+  justify-content: flex-end;
+  text-align: right;
 }
 
 .nav a {
@@ -115,6 +124,7 @@ body {
   color: #f0f0f0;
   cursor: pointer;
   transition: border-color 0.2s ease, background 0.2s ease;
+  margin-left: auto;
 }
 
 .nav-toggle:hover,


### PR DESCRIPTION
## Summary
- add the EmNet wordmark next to the navbar logo across each page
- adjust navbar layout styles so the links align to the right while keeping the toggle on the right for mobile
- increase the navbar logo height so it fills the header space more prominently

## Testing
- Not run (static site change)

------
https://chatgpt.com/codex/tasks/task_e_68dfd57ba16c8322aad7d660d0e27c78