### PR TITLE
Adjust hero hero logo spacing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -216,6 +216,10 @@ body {
   isolation: isolate;
 }
 
+.hero-home .hero-banner-content {
+  padding-top: clamp(60px, 14vw, 128px);
+}
+
 .hero-home .hero-banner::after {
   top: calc(-1 * var(--hero-home-offset));
   bottom: 0;
@@ -330,6 +334,10 @@ body {
   margin: clamp(32px, 8vw, 64px) auto 20px;
   width: clamp(88px, 18vw, 160px);
   height: auto;
+}
+
+.hero-home .hero-logo {
+  margin: clamp(72px, 14vw, 140px) auto clamp(8px, 2vw, 16px);
 }
 
 body.about-page .hero-logo {


### PR DESCRIPTION
## Summary
- increase the top padding within the home hero banner to guarantee space above the logo
- tighten the gap between the hero logo and headline while keeping other pages unaffected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfda1e53348322aa7a08c39ba5262c