### PR TITLE
Adjust hero banner layout for responsive height

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,8 @@
       </ul>
     </section>
 
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true" width="1024" height="341" loading="lazy" decoding="async">
+
     <section id="practical-examples" class="section trust-strip">
       <div class="container">
         <h2 class="scroll-animate">Bespoke bot build examples</h2>
@@ -131,11 +133,15 @@
       </div>
     </section>
 
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true" width="1024" height="341" loading="lazy" decoding="async">
+
     <section id="about" class="container section">
       <h2 class="scroll-animate">About Us</h2>
       <p>EmNet manages the backbone of online communities. From scalable moderation to purpose-built tools and reporting. Growth that reflects reality.</p>
       <a class="btn" href="about.html">Hear from our founder</a>
     </section>
+
+    <img src="assets/divider.png" alt="" class="section-divider" aria-hidden="true" width="1024" height="341" loading="lazy" decoding="async">
 
     <section id="contact" class="container section final-cta">
       <h2 class="scroll-animate">Next step</h2>

--- a/styles/main.css
+++ b/styles/main.css
@@ -168,12 +168,14 @@ body {
 .hero-banner {
   position: relative;
   width: 100%;
+  display: grid;
 }
 
 .hero-banner-image {
+  grid-area: 1 / 1;
   display: block;
   width: 100%;
-  height: clamp(280px, 45vw, 520px);
+  height: auto;
   object-fit: cover;
 }
 
@@ -186,13 +188,13 @@ body {
 }
 
 .hero-banner-content {
-  inset: 0;
+  grid-area: 1 / 1;
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
   padding: clamp(20px, 5vw, 48px) 20px;
-  position: absolute;
+  position: relative;
   z-index: 2;
 }
 
@@ -206,33 +208,21 @@ body {
 }
 
 .hero-home {
-  --hero-home-offset: clamp(64px, 12vw, 120px);
-  --hero-home-visual-height: clamp(360px, 70vw, 620px);
-  padding: var(--hero-home-offset) 0 0;
+  padding: clamp(56px, 14vw, 128px) 0 0;
 }
 
 .hero-home .hero-banner {
-  min-height: var(--hero-home-visual-height);
   isolation: isolate;
+  justify-items: center;
 }
 
 .hero-home .hero-banner-content {
-  padding-top: clamp(60px, 14vw, 128px);
+  padding-top: clamp(40px, 12vw, 96px);
+  padding-bottom: clamp(32px, 10vw, 80px);
 }
 
 .hero-home .hero-banner::after {
-  top: calc(-1 * var(--hero-home-offset));
-  bottom: 0;
-}
-
-.hero-home .hero-banner-image {
-  position: absolute;
-  top: calc(-1 * var(--hero-home-offset));
-  left: 0;
-  width: 100%;
-  height: calc(var(--hero-home-visual-height) + var(--hero-home-offset));
-  object-fit: cover;
-  z-index: 0;
+  inset: 0;
 }
 
 .hero-home .hero-banner-content .container {


### PR DESCRIPTION
## Summary
- switch the hero banner to a grid-based overlay so the background image can grow naturally
- remove the fixed height and offset on the home page hero to prevent vertical cropping on small screens
- tune hero content spacing to preserve layout across viewports
- insert divider imagery between homepage sections for consistent separation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe1b5f2d88322849552dca1f85e89