### PR TITLE
Adjust hero layout and mobile navigation overlay

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -4,8 +4,8 @@
 }
 
 :root {
-  --header-logo-height: clamp(40px, 6vw, 64px);
-  --header-vertical-padding: clamp(12px, 2.5vw, 20px);
+  --header-logo-height: clamp(28px, 4.2vw, 45px);
+  --header-vertical-padding: clamp(8px, 1.75vw, 14px);
   --site-header-height: calc(var(--header-logo-height) + (var(--header-vertical-padding) * 2));
   --cookie-banner-height: 0px;
 }
@@ -172,6 +172,7 @@ body {
   display: grid;
   min-height: clamp(420px, 68vh, 680px);
   border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   overflow: hidden;
 }
 
@@ -212,7 +213,7 @@ body {
 }
 
 .hero-home {
-  padding: clamp(24px, 10vw, 72px) 0 0;
+  padding: clamp(16px, 8vw, 48px) 0 0;
 }
 
 .hero-home .hero-banner {
@@ -222,8 +223,9 @@ body {
 
 .hero-home .hero-banner-content {
   align-items: flex-start;
-  padding-top: clamp(16px, 6vw, 48px);
-  padding-bottom: clamp(20px, 6vw, 48px);
+  justify-content: flex-start;
+  padding-top: clamp(12px, 4vw, 32px);
+  padding-bottom: clamp(18px, 5vw, 40px);
 }
 
 .hero-home .hero-banner::after {
@@ -232,7 +234,7 @@ body {
 
 
 .hero-home .hero-banner-content .container {
-  gap: clamp(16px, 4vw, 24px);
+  gap: clamp(14px, 3.5vw, 22px);
 }
 
 .hero-about h1 {
@@ -327,13 +329,13 @@ body {
 
 .hero-logo {
   display: block;
-  margin: clamp(32px, 8vw, 64px) auto 20px;
+  margin: 0 auto clamp(12px, 3.5vw, 20px);
   width: clamp(88px, 18vw, 160px);
   height: auto;
 }
 
 .hero-home .hero-logo {
-  margin: clamp(16px, 6vw, 40px) auto clamp(10px, 3vw, 18px);
+  margin: 0 auto clamp(10px, 3vw, 18px);
 }
 
 body.about-page .hero-logo {
@@ -1689,14 +1691,20 @@ body.cookie-banner-visible {
   }
 
   .nav {
-    width: 100%;
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    width: min(320px, calc(100vw - 48px));
     flex-direction: column;
     align-items: stretch;
-    border-top: 1px solid #222;
-    margin-top: 8px;
-    padding-top: 12px;
+    gap: 4px;
+    padding: 12px;
     display: none;
     background: #111;
+    border: 1px solid #222;
+    border-radius: 12px;
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.45);
+    z-index: 20;
   }
 
   .nav.is-open {
@@ -1705,8 +1713,9 @@ body.cookie-banner-visible {
 
   .nav a {
     margin: 0;
-    padding: 10px 0;
+    padding: 10px 16px;
     border-radius: 8px;
+    text-align: left;
   }
 
   .hero {
@@ -1719,7 +1728,7 @@ body.cookie-banner-visible {
   }
 
   .hero-logo {
-    margin: clamp(40px, 16vw, 72px) auto 24px;
+    margin: 0 auto clamp(12px, 4vw, 20px);
   }
 
   .hero h1 {


### PR DESCRIPTION
## Summary
- reduce header logo size and padding to shrink the site header height
- adjust hero spacing, border, and logo positioning for a tighter layout
- update the mobile navigation to open as an overlay dropdown with a constrained width

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dff0f44cdc8322bb4c9c43d17461da