### PR TITLE
Adjust marquee badge layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
 
   <div class="announcement-marquee js-announcement-marquee" role="region" aria-live="polite" aria-label="Latest updates" hidden>
     <div class="container announcement-marquee__viewport">
+      <img src="assets/live.jpg" alt="Live updates" class="announcement-marquee__badge" width="512" height="512" decoding="async">
       <div class="announcement-marquee__track js-marquee-track">
         <div class="announcement-marquee__content js-marquee-content"></div>
       </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -75,9 +75,23 @@ body {
   position: relative;
   overflow: hidden;
   padding: 8px 0;
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.announcement-marquee__badge {
+  flex: 0 0 auto;
+  align-self: stretch;
+  width: auto;
+  height: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  opacity: 0.8;
 }
 
 .announcement-marquee__track {
+  flex: 1 1 auto;
   display: flex;
   align-items: center;
   width: max-content;


### PR DESCRIPTION
## Summary
- lay out the Live badge alongside the marquee content instead of overlaying it
- scale the badge to fit within the marquee height without cropping and soften its opacity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e01a10848483228479b0338e1b56d3