### PR TITLE
Adjust marquee badge sizing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -62,6 +62,7 @@ body {
 }
 
 .announcement-marquee {
+  --announcement-marquee-height: 48px;
   background: #0d0d0d;
   border-bottom: 1px solid #222;
   color: #f0f0f0;
@@ -74,17 +75,17 @@ body {
 .announcement-marquee__viewport {
   position: relative;
   overflow: hidden;
-  padding: 8px 0;
+  padding: 8px 12px;
+  min-height: var(--announcement-marquee-height);
   display: flex;
-  align-items: stretch;
+  align-items: center;
   gap: 12px;
 }
 
 .announcement-marquee__badge {
   flex: 0 0 auto;
-  align-self: stretch;
   width: auto;
-  height: 100%;
+  height: calc(var(--announcement-marquee-height) - 16px);
   max-height: 100%;
   object-fit: contain;
   opacity: 0.8;


### PR DESCRIPTION
## Summary
- set a consistent height for the announcement marquee and align its layout
- size the live update badge to match the marquee height for consistent display

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01e6fecd88322b7c8548ee69879d6