### PR TITLE
Restore horizontal marquee layout with styled live badge

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -75,11 +75,12 @@ body {
 .announcement-marquee__viewport {
   position: relative;
   overflow: hidden;
-  padding: 8px 12px;
+  padding: 12px;
   min-height: var(--announcement-marquee-height);
   display: flex;
+  flex-direction: row;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
 }
 
 .announcement-marquee__badge {
@@ -88,15 +89,19 @@ body {
   height: calc(var(--announcement-marquee-height) - 16px);
   max-height: 100%;
   object-fit: contain;
-  opacity: 0.8;
+  opacity: 0.9;
+  background-color: #000;
+  padding: 6px 12px;
+  border-radius: 999px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
 }
 
 .announcement-marquee__track {
   flex: 1 1 auto;
   display: flex;
   align-items: center;
-  width: max-content;
-  min-width: 100%;
+  min-width: 0;
+  width: 100%;
   gap: 0;
   animation: marquee-scroll var(--marquee-duration, 38s) linear infinite;
 }


### PR DESCRIPTION
## Summary
- return the announcement marquee viewport to a single-row layout so the badge leads the scrolling updates
- keep the live badge image in place while giving it a pill-shaped black background and richer shadow
- allow the marquee track to span the remaining width for one continuous bar of updates

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0201d59608322a790c1fcd7386982