### PR TITLE
Ensure live badge overlays marquee

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -94,6 +94,8 @@ body {
   padding: 6px 12px;
   border-radius: 999px;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+  position: relative;
+  z-index: 2;
 }
 
 .announcement-marquee__track {
@@ -104,6 +106,8 @@ body {
   width: 100%;
   gap: 0;
   animation: marquee-scroll var(--marquee-duration, 38s) linear infinite;
+  position: relative;
+  z-index: 1;
 }
 
 .announcement-marquee__content {


### PR DESCRIPTION
## Summary
- raise the marquee badge above the scrolling content so the ticker slides underneath it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e02459a7388322986bdf801a5ca4a3