### PR TITLE
Speed up announcement marquee

### DIFF
--- a/assets/site.js
+++ b/assets/site.js
@@ -101,7 +101,13 @@ if (window.top !== window.self) {
     marqueeContent.appendChild(fragment);
 
     const totalCharacters = entries.reduce((total, entry) => total + entry.message.length, 0);
-    const durationSeconds = Math.min(Math.max(totalCharacters * 0.4, 28), 60);
+    const charactersPerSecond = 12;
+    const minDuration = 12;
+    const maxDuration = 30;
+    const durationSeconds = Math.min(
+      Math.max(totalCharacters / charactersPerSecond, minDuration),
+      maxDuration,
+    );
     marquee.style.setProperty('--marquee-duration', `${durationSeconds}s`);
 
     marqueeTrack.querySelectorAll('.announcement-marquee__content--clone').forEach((clone) => {


### PR DESCRIPTION
## Summary
- increase the announcement marquee scroll speed by recalculating duration based on character count
- clamp the marquee animation duration to a faster range for better readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e028d65efc8322b9872e1992b5a0b9