### PR TITLE
Slow marquee scroll and add live badge to all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -74,6 +74,7 @@
 
   <div class="announcement-marquee js-announcement-marquee" role="region" aria-live="polite" aria-label="Latest updates" hidden>
     <div class="container announcement-marquee__viewport">
+      <img src="assets/live.jpg" alt="Live updates" class="announcement-marquee__badge" width="512" height="512" decoding="async">
       <div class="announcement-marquee__track js-marquee-track">
         <div class="announcement-marquee__content js-marquee-content"></div>
       </div>

--- a/algoland.html
+++ b/algoland.html
@@ -83,6 +83,7 @@
 
   <div class="announcement-marquee js-announcement-marquee" role="region" aria-live="polite" aria-label="Latest updates" hidden>
     <div class="container announcement-marquee__viewport">
+      <img src="assets/live.jpg" alt="Live updates" class="announcement-marquee__badge" width="512" height="512" decoding="async">
       <div class="announcement-marquee__track js-marquee-track">
         <div class="announcement-marquee__content js-marquee-content"></div>
       </div>

--- a/assets/site.js
+++ b/assets/site.js
@@ -359,9 +359,9 @@ if (window.top !== window.self) {
     marqueeContent.appendChild(fragment);
 
     const totalCharacters = entries.reduce((total, entry) => total + entry.message.length, 0);
-    const charactersPerSecond = 18;
-    const minDuration = 12;
-    const maxDuration = 15;
+    const charactersPerSecond = 9;
+    const minDuration = 24;
+    const maxDuration = 30;
     const durationSeconds = Math.min(
       Math.max(totalCharacters / charactersPerSecond, minDuration),
       maxDuration,

--- a/contact.html
+++ b/contact.html
@@ -76,6 +76,7 @@
 
   <div class="announcement-marquee js-announcement-marquee" role="region" aria-live="polite" aria-label="Latest updates" hidden>
     <div class="container announcement-marquee__viewport">
+      <img src="assets/live.jpg" alt="Live updates" class="announcement-marquee__badge" width="512" height="512" decoding="async">
       <div class="announcement-marquee__track js-marquee-track">
         <div class="announcement-marquee__content js-marquee-content"></div>
       </div>

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -96,6 +96,7 @@
 
   <div class="announcement-marquee js-announcement-marquee" role="region" aria-live="polite" aria-label="Latest updates" hidden>
     <div class="container announcement-marquee__viewport">
+      <img src="assets/live.jpg" alt="Live updates" class="announcement-marquee__badge" width="512" height="512" decoding="async">
       <div class="announcement-marquee__track js-marquee-track">
         <div class="announcement-marquee__content js-marquee-content"></div>
       </div>

--- a/privacy.html
+++ b/privacy.html
@@ -66,6 +66,7 @@
 
   <div class="announcement-marquee js-announcement-marquee" role="region" aria-live="polite" aria-label="Latest updates" hidden>
     <div class="container announcement-marquee__viewport">
+      <img src="assets/live.jpg" alt="Live updates" class="announcement-marquee__badge" width="512" height="512" decoding="async">
       <div class="announcement-marquee__track js-marquee-track">
         <div class="announcement-marquee__content js-marquee-content"></div>
       </div>

--- a/services.html
+++ b/services.html
@@ -80,6 +80,7 @@
 
   <div class="announcement-marquee js-announcement-marquee" role="region" aria-live="polite" aria-label="Latest updates" hidden>
     <div class="container announcement-marquee__viewport">
+      <img src="assets/live.jpg" alt="Live updates" class="announcement-marquee__badge" width="512" height="512" decoding="async">
       <div class="announcement-marquee__track js-marquee-track">
         <div class="announcement-marquee__content js-marquee-content"></div>
       </div>


### PR DESCRIPTION
## Summary
- halve the marquee scrolling speed by doubling the animation duration thresholds
- show the live update badge on every page's announcement marquee for consistency

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e033f135e08322a42bad7235022511