### PR TITLE
Open Algoland week 3 challenge

### DIFF
--- a/algoland.html
+++ b/algoland.html
@@ -148,17 +148,17 @@
           <p class="week-card__badge">Badge ASA <span data-week-badge>3215542840</span></p>
           <p class="week-card__opens" data-week-open-text>Opened 29 September 2025</p>
         </article>
-        <article class="week-card" data-week-card data-week="3" data-opens-on="2025-10-06">
+        <article class="week-card is-open has-rollover" data-week-card data-week="3" data-opens-on="2025-10-06">
           <div class="week-card__header">
             <h3>Week 3</h3>
-            <p class="week-card__status" data-week-status>Ready for Coming Monday</p>
+            <p class="week-card__status" data-week-status>Open now</p>
           </div>
           <p class="week-card__count">
             <span class="week-card__count-number" data-week-completions>—</span>
             <span class="week-card__count-label">badges claimed</span>
           </p>
           <p class="week-card__badge">Badge ASA <span data-week-badge>3215542836</span></p>
-          <p class="week-card__opens" data-week-open-text>Opens Monday 6 October 2025</p>
+          <p class="week-card__opens" data-week-open-text>Opened 6 October 2025</p>
         </article>
         <article class="week-card" data-week-card data-week="4" data-opens-on="2025-10-13">
           <div class="week-card__header">

--- a/styles/main.css
+++ b/styles/main.css
@@ -1403,6 +1403,10 @@ body.about-page .hero-logo {
   background-image: linear-gradient(180deg, rgba(8, 8, 8, 0.6), rgba(8, 8, 8, 0.85)), url('../assets/week2.png');
 }
 
+.algoland-page .week-card.has-rollover[data-week="3"]::before {
+  background-image: linear-gradient(180deg, rgba(8, 8, 8, 0.6), rgba(8, 8, 8, 0.85)), url('../assets/week3.png');
+}
+
 .algoland-page .week-card.is-open {
   background: rgba(25, 25, 25, 0.9);
   border-color: rgba(38, 211, 197, 0.4);


### PR DESCRIPTION
## Summary
- mark the Algoland week 3 card as open with the correct status text and opening date
- enable the week 3 rollover artwork by referencing the new week3.png asset

## Testing
- no automated tests were run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e3c3a4963c83228d27be803c574469