### PR TITLE
Add Algorand trademark disclaimer to privacy messaging

### DIFF
--- a/about.html
+++ b/about.html
@@ -126,6 +126,7 @@
         <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
         <small><a href="privacy.html">Privacy Policy</a></small>
         <small>Proudly aligned with the Algorand ecosystem.</small>
+        <small>Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
@@ -136,7 +137,7 @@
   </footer>
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
-      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>. <span class="cookie-banner__note">Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</span></p>
       <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
         <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
         <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>

--- a/algoland.html
+++ b/algoland.html
@@ -435,6 +435,7 @@
         <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
         <small><a href="privacy.html">Privacy Policy</a></small>
         <small>Proudly aligned with the Algorand ecosystem.</small>
+        <small>Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>

--- a/contact.html
+++ b/contact.html
@@ -163,6 +163,7 @@
         <small>© <span class="js-current-year"></span> EmNet Community Management Limited, Company No. 13716390, Registrar of Companies for England and Wales</small>
         <small><a href="privacy.html">Privacy Policy</a></small>
         <small>Proudly aligned with the Algorand ecosystem.</small>
+        <small>Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
@@ -173,7 +174,7 @@
   </footer>
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
-      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>. <span class="cookie-banner__note">Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</span></p>
       <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
         <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
         <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>

--- a/how-we-work.html
+++ b/how-we-work.html
@@ -242,6 +242,7 @@
         <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
         <small><a href="privacy.html">Privacy Policy</a></small>
         <small>Proudly aligned with the Algorand ecosystem.</small>
+        <small>Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
@@ -252,7 +253,7 @@
   </footer>
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
-      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>. <span class="cookie-banner__note">Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</span></p>
       <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
         <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
         <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>

--- a/index.html
+++ b/index.html
@@ -170,6 +170,7 @@
         <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
         <small><a href="privacy.html">Privacy Policy</a></small>
         <small>Proudly aligned with the Algorand ecosystem.</small>
+        <small>Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
@@ -180,7 +181,7 @@
   </footer>
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
-      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>. <span class="cookie-banner__note">Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</span></p>
       <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
         <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
         <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>

--- a/privacy.html
+++ b/privacy.html
@@ -78,6 +78,7 @@
     <p>Last updated: 2 October 2025</p>
 
     <p>EmNet Community Management Ltd (“EmNet”, “we”, “our”, or “us”) operates this website to provide information about our services. We respect your privacy and are committed to protecting it.</p>
+    <p>Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</p>
 
     <h2>Information we collect</h2>
     <p>This website itself does not actively collect personal information. However, certain information is collected automatically by our hosting provider (GitHub Pages) when you visit the site. This may include your IP address, browser type, and standard log data necessary to deliver the site securely.</p>
@@ -115,6 +116,7 @@
         <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
         <small><a href="privacy.html" aria-current="page">Privacy Policy</a></small>
         <small>Proudly aligned with the Algorand ecosystem.</small>
+        <small>Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
@@ -125,7 +127,7 @@
   </footer>
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
-      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>. <span class="cookie-banner__note">Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</span></p>
       <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
         <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
         <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>

--- a/services.html
+++ b/services.html
@@ -204,6 +204,7 @@
         <small>Telegram: <a href="https://t.me/millieme85" target="_blank" rel="noopener">EmnetCm</a></small>
         <small><a href="privacy.html">Privacy Policy</a></small>
         <small>Proudly aligned with the Algorand ecosystem.</small>
+        <small>Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</small>
       </div>
       <ul class="footer-social" aria-label="Contact and social links">
         <li><a href="mailto:Emnet@emnetcm.com">✉️</a></li>
@@ -214,7 +215,7 @@
   </footer>
   <div class="cookie-banner js-cookie-banner" role="region" aria-label="Cookie consent">
     <div class="container cookie-banner__inner">
-      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>.</p>
+      <p class="cookie-banner__message">We use cookies to improve your experience. By continuing you accept our <a href="privacy.html">Privacy Policy</a>. <span class="cookie-banner__note">Algorand® is a registered trademark of Algorand, Inc. Use of the Algoland tracker is a community-created tool, and EmNet is independent and part of the Algorand community — we are not affiliated with or endorsed by the Algorand Foundation.</span></p>
       <div class="cookie-banner__actions" role="group" aria-label="Cookie choices">
         <a class="cookie-banner__button cookie-banner__button--secondary js-cookie-decline" href="privacy.html">Decline</a>
         <button type="button" class="cookie-banner__button cookie-banner__button--primary js-cookie-accept">Accept</button>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1710,6 +1710,12 @@ body.cookie-banner-visible {
   color: #f0f0f0;
 }
 
+.cookie-banner__note {
+  display: block;
+  margin-top: 8px;
+  color: #d8d8d8;
+}
+
 .cookie-banner__message a {
   color: #ff2ebd;
   text-decoration: underline;


### PR DESCRIPTION
## Summary
- extend the cookie banner copy with the Algorand trademark and independence disclaimer
- add the same Algorand notice to the privacy policy and site footers for consistent messaging
- style the new banner note for readability

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68e3ee59682c8322948090649c718542