### PR TITLE
Dynamically build prize modal and update week 1 ASA

### DIFF
--- a/algoland.html
+++ b/algoland.html
@@ -133,7 +133,7 @@
             <span class="week-card__count-number" data-week-completions>—</span>
             <span class="week-card__count-label">badges claimed</span>
           </p>
-          <p class="week-card__badge">Badge ASA <span data-week-badge>3215542831</span></p>
+          <p class="week-card__badge">Badge ASA <span data-week-badge>3215542832</span></p>
           <p class="week-card__opens" data-week-open-text>Opened 22 September 2025</p>
         </article>
         <article class="week-card is-open has-rollover" data-week-card data-week="2" data-opens-on="2025-09-29">
@@ -306,7 +306,7 @@
           <tbody>
             <tr data-week="1">
               <th scope="row">Week 1</th>
-              <td data-col="badge" class="is-hidden-column">3215542831</td>
+              <td data-col="badge" class="is-hidden-column">3215542832</td>
               <td data-col="distributor" data-distributor-index="0" class="is-hidden-column"></td>
               <td data-col="entrants" title="Wallets opted in to application 3215540125." class="is-hidden-column">—</td>
               <td data-col="completed" title="Wallets that received the week’s badge from the official distributor.">—</td>

--- a/assets/algoland.js
+++ b/assets/algoland.js
@@ -10,9 +10,10 @@
   const ONE_WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
   const DEFAULT_DISTRIBUTOR = 'HHADCZKQV24QDCBER5GTOH7BOLF4ZQ6WICNHAA3GZUECIMJXIIMYBIWEZM';
   const APP_ID = 3215540125;
+  const prizeModal = createPrizeModal();
 
   const weeksConfig = [
-    { week: 1, assetId: '3215542831', distributors: [DEFAULT_DISTRIBUTOR], opensOn: '2025-09-22' },
+    { week: 1, assetId: '3215542832', distributors: [DEFAULT_DISTRIBUTOR], opensOn: '2025-09-22' },
     { week: 2, assetId: '3215542840', distributors: [DEFAULT_DISTRIBUTOR], opensOn: '2025-09-29' },
     { week: 3, assetId: '3215542836', distributors: [DEFAULT_DISTRIBUTOR], opensOn: '2025-10-06' },
     { week: 4, assetId: '', distributors: [DEFAULT_DISTRIBUTOR], opensOn: '2025-10-13' },
@@ -59,6 +60,7 @@
   const table = root.querySelector('[data-algoland-table]');
   const updatedElement = root.querySelector('[data-algoland-updated]');
   const weekCards = createWeekCardMap();
+  attachWeekCardInteractions();
 
   const state = {
     snapshot: loadSnapshot(),
@@ -450,6 +452,29 @@
     return new Map(entries);
   }
 
+  function attachWeekCardInteractions() {
+    if (!prizeModal) {
+      return;
+    }
+    weekCards.forEach((entry, week) => {
+      if (!entry || !entry.card) {
+        return;
+      }
+      const { card } = entry;
+      card.setAttribute('role', 'button');
+      card.setAttribute('tabindex', '0');
+      card.addEventListener('click', () => {
+        openPrizeModalForWeek(week);
+      });
+      card.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          openPrizeModalForWeek(week);
+        }
+      });
+    });
+  }
+
   function renderTable(snapshot) {
     if (!table) {
       return;
@@ -569,5 +594,323 @@
     } else {
       updatedElement.textContent = `Last updated ${formatted}`;
     }
+  }
+
+  function openPrizeModalForWeek(week) {
+    if (!prizeModal) {
+      return;
+    }
+    prizeModal.open(week);
+  }
+
+  async function fetchPrizeDetails(week) {
+    const response = await fetch(buildApiUrl(`/api/prizes/${week}`), {
+      headers: { accept: 'application/json' },
+      credentials: 'omit',
+    });
+    if (!response.ok) {
+      throw new Error(`Prize request failed with status ${response.status}`);
+    }
+    return response.json();
+  }
+
+  function createPrizeModal() {
+    let modal = document.querySelector('[data-prize-modal]');
+    if (!modal) {
+      modal = document.createElement('div');
+      modal.className = 'prize-modal';
+      modal.hidden = true;
+      modal.setAttribute('data-prize-modal', '');
+
+      const overlay = document.createElement('div');
+      overlay.className = 'prize-modal__overlay';
+      overlay.setAttribute('data-prize-dismiss', '');
+      overlay.setAttribute('aria-hidden', 'true');
+
+      const dialog = document.createElement('div');
+      dialog.className = 'prize-modal__dialog';
+      dialog.setAttribute('data-prize-dialog', '');
+      dialog.setAttribute('role', 'dialog');
+      dialog.setAttribute('aria-modal', 'true');
+      dialog.setAttribute('aria-labelledby', 'prize-modal-title');
+      dialog.tabIndex = -1;
+
+      const closeButton = document.createElement('button');
+      closeButton.type = 'button';
+      closeButton.className = 'prize-modal__close';
+      closeButton.setAttribute('data-prize-dismiss', '');
+      closeButton.setAttribute('data-prize-close', '');
+      closeButton.setAttribute('aria-label', 'Close prize details');
+      const closeIcon = document.createElement('span');
+      closeIcon.setAttribute('aria-hidden', 'true');
+      closeIcon.textContent = '×';
+      closeButton.appendChild(closeIcon);
+
+      const content = document.createElement('div');
+      content.className = 'prize-modal__content';
+
+      const titleElement = document.createElement('h2');
+      titleElement.id = 'prize-modal-title';
+      titleElement.setAttribute('data-prize-title', '');
+      titleElement.textContent = 'Prize details';
+
+      const bodyElement = document.createElement('div');
+      bodyElement.className = 'prize-modal__body';
+      bodyElement.setAttribute('data-prize-body', '');
+      const loadingMessage = document.createElement('p');
+      loadingMessage.className = 'prize-modal__message';
+      loadingMessage.textContent = 'Loading prize details…';
+      bodyElement.appendChild(loadingMessage);
+
+      content.appendChild(titleElement);
+      content.appendChild(bodyElement);
+
+      dialog.appendChild(closeButton);
+      dialog.appendChild(content);
+
+      modal.appendChild(overlay);
+      modal.appendChild(dialog);
+
+      const host = document.body || root || document.documentElement;
+      host.appendChild(modal);
+    }
+
+    const dialog = modal.querySelector('[data-prize-dialog]');
+    const titleElement = modal.querySelector('[data-prize-title]');
+    const bodyElement = modal.querySelector('[data-prize-body]');
+    const dismissElements = modal.querySelectorAll('[data-prize-dismiss]');
+    if (!dialog || !titleElement || !bodyElement) {
+      return null;
+    }
+    let lastFocusedElement = null;
+    let activeRequestId = 0;
+
+    function open(week) {
+      activeRequestId += 1;
+      const requestId = activeRequestId;
+      modal.hidden = false;
+      modal.dataset.open = 'true';
+      modal.dataset.week = String(week);
+      document.body.classList.add('prize-modal-open');
+      lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      if (titleElement) {
+        titleElement.textContent = `Week ${week} prize`;
+      }
+      renderLoading();
+      window.requestAnimationFrame(() => {
+        const closeButton = modal.querySelector('[data-prize-close]');
+        if (closeButton instanceof HTMLElement) {
+          closeButton.focus();
+        } else if (dialog instanceof HTMLElement) {
+          dialog.focus();
+        }
+      });
+      fetchPrizeDetails(week)
+        .then((data) => {
+          if (activeRequestId !== requestId) {
+            return;
+          }
+          renderPrizeDetails(data, week);
+        })
+        .catch((error) => {
+          if (activeRequestId !== requestId) {
+            return;
+          }
+          console.warn('[Algoland] Failed to load prize details', error);
+          renderError();
+        });
+    }
+
+    function close() {
+      if (modal.hidden) {
+        return;
+      }
+      activeRequestId += 1;
+      modal.hidden = true;
+      modal.dataset.open = 'false';
+      delete modal.dataset.week;
+      document.body.classList.remove('prize-modal-open');
+      if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+        lastFocusedElement.focus();
+      }
+    }
+
+    function renderLoading() {
+      if (!bodyElement) {
+        return;
+      }
+      bodyElement.textContent = '';
+      const paragraph = document.createElement('p');
+      paragraph.className = 'prize-modal__message';
+      paragraph.textContent = 'Loading prize details…';
+      bodyElement.appendChild(paragraph);
+    }
+
+    function renderPrizeDetails(data, week) {
+      if (!bodyElement) {
+        return;
+      }
+      if (!data || data.status === 'coming-soon') {
+        renderComingSoon(data, week);
+        return;
+      }
+      bodyElement.textContent = '';
+      const fragment = document.createDocumentFragment();
+
+      if (data.image) {
+        const image = document.createElement('img');
+        image.className = 'prize-modal__image';
+        image.src = buildPrizeImageUrl(data.image);
+        image.alt = `Week ${week} prize`;
+        image.decoding = 'async';
+        image.loading = 'lazy';
+        fragment.appendChild(image);
+      }
+
+      if (data.asa) {
+        const asaParagraph = document.createElement('p');
+        asaParagraph.className = 'prize-modal__asa';
+        asaParagraph.textContent = `Prize ASA: ${data.asa}`;
+        fragment.appendChild(asaParagraph);
+      }
+
+      const message = document.createElement('p');
+      message.className = 'prize-modal__message';
+      message.textContent = `Congratulations to our Week ${week} prize winners!`;
+      fragment.appendChild(message);
+
+      const winnersHeading = document.createElement('h3');
+      winnersHeading.className = 'prize-modal__subheading';
+      winnersHeading.textContent = 'Winners';
+      fragment.appendChild(winnersHeading);
+
+      const winners = Array.isArray(data.winners) ? data.winners : [];
+      if (winners.length > 0) {
+        const list = document.createElement('ul');
+        list.className = 'prize-modal__winners';
+        winners.forEach((address) => {
+          const item = document.createElement('li');
+          item.textContent = address;
+          list.appendChild(item);
+        });
+        fragment.appendChild(list);
+      } else {
+        const emptyState = document.createElement('p');
+        emptyState.className = 'prize-modal__empty';
+        emptyState.textContent = 'No prize holders have been recorded yet. Check back soon.';
+        fragment.appendChild(emptyState);
+      }
+
+      const updatedLabel = formatPrizeTimestamp(data.updatedAt);
+      if (updatedLabel) {
+        const meta = document.createElement('p');
+        meta.className = 'prize-modal__meta';
+        if (data.stale) {
+          meta.textContent = `Last updated ${updatedLabel} (stale)`;
+        } else {
+          meta.textContent = `Last updated ${updatedLabel}`;
+        }
+        fragment.appendChild(meta);
+      }
+
+      if (typeof data.winnersCount === 'number') {
+        const countMeta = document.createElement('p');
+        countMeta.className = 'prize-modal__meta';
+        countMeta.textContent = `Winner count: ${data.winnersCount}`;
+        fragment.appendChild(countMeta);
+      }
+
+      bodyElement.appendChild(fragment);
+    }
+
+    function renderComingSoon(data, week) {
+      if (!bodyElement) {
+        return;
+      }
+      bodyElement.textContent = '';
+      if (data && data.image) {
+        const image = document.createElement('img');
+        image.className = 'prize-modal__image';
+        image.src = buildPrizeImageUrl(data.image);
+        image.alt = `Week ${week} prize`;
+        image.decoding = 'async';
+        image.loading = 'lazy';
+        bodyElement.appendChild(image);
+      }
+      const message = document.createElement('p');
+      message.className = 'prize-modal__message';
+      const text = data && data.message ? data.message : 'Prize details coming soon. Check back soon.';
+      message.textContent = text;
+      bodyElement.appendChild(message);
+      if (data && data.asa) {
+        const asa = document.createElement('p');
+        asa.className = 'prize-modal__asa';
+        asa.textContent = `Prize ASA: ${data.asa}`;
+        bodyElement.appendChild(asa);
+      }
+    }
+
+    function renderError() {
+      if (!bodyElement) {
+        return;
+      }
+      bodyElement.textContent = '';
+      const message = document.createElement('p');
+      message.className = 'prize-modal__message';
+      message.textContent = 'Unable to load prize details right now. Please try again shortly.';
+      bodyElement.appendChild(message);
+    }
+
+    dismissElements.forEach((element) => {
+      element.addEventListener('click', (event) => {
+        event.preventDefault();
+        close();
+      });
+    });
+
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        close();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && modal.dataset.open === 'true') {
+        close();
+      }
+    });
+
+    return { open, close };
+  }
+
+  function buildPrizeImageUrl(imageName) {
+    if (!imageName) {
+      return '';
+    }
+    if (typeof imageName !== 'string') {
+      return '';
+    }
+    if (/^(https?:)?\/\//i.test(imageName) || imageName.startsWith('/')) {
+      return imageName;
+    }
+    return `assets/${imageName}`;
+  }
+
+  function formatPrizeTimestamp(value) {
+    if (!value) {
+      return '';
+    }
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return '';
+    }
+    return parsed.toLocaleString('en-GB', {
+      hour: '2-digit',
+      minute: '2-digit',
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      timeZoneName: 'short',
+    });
   }
 })();

--- a/backend/README.md
+++ b/backend/README.md
@@ -33,6 +33,6 @@ The service listens on `http://localhost:3000` by default. Configure the followi
 4. After deployment succeeds, verify:
    - `/api/ping` responds with service metadata.
    - `/api/entrants` returns the entrants count and timestamp.
-   - `/api/completions?asset=3215542831` returns the completions count for week 1.
+   - `/api/completions?asset=3215542832` returns the completions count for week 1.
 
 Remember to update the static site configuration so `/algoland` fetches data from the deployed Render URL.

--- a/backend/config.js
+++ b/backend/config.js
@@ -3,7 +3,7 @@ const PARSED_APP_ID = Number.parseInt(RAW_APP_ID, 10);
 export const APP_ID = Number.isFinite(PARSED_APP_ID) ? PARSED_APP_ID : 3215540125;
 
 export const WEEK_CONFIG = [
-  { week: 1, assetId: 3215542831 },
+  { week: 1, assetId: 3215542832 },
   { week: 2, assetId: 3215542840 },
   { week: 3, assetId: null },
   { week: 4, assetId: null },
@@ -23,7 +23,7 @@ const DEFAULT_DISTRIBUTOR = 'HHADCZKQV24QDCBER5GTOH7BOLF4ZQ6WICNHAA3GZUECIMJXIIM
 export const DISTRIBUTOR_ALLOWLIST = {
   default: [DEFAULT_DISTRIBUTOR],
   byAsset: {
-    3215542831: [DEFAULT_DISTRIBUTOR],
+    3215542832: [DEFAULT_DISTRIBUTOR],
     3215542840: [DEFAULT_DISTRIBUTOR],
   },
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -5,6 +5,7 @@ import NodeCache from 'node-cache';
 import { performance } from 'node:perf_hooks';
 
 import { APP_ID, DISTRIBUTOR_ALLOWLIST, WEEK_CONFIG, getAllowlistForAsset } from './config.js';
+import { getAllPrizes, getPrizeForWeek } from './prizeStore.js';
 
 const app = express();
 app.disable('x-powered-by');
@@ -59,6 +60,14 @@ const assetMetadataCache = new NodeCache({
   checkperiod: 60 * 60,
   useClones: false,
 });
+
+const assetHoldersCache = new NodeCache({
+  stdTTL: 0,
+  checkperiod: 0,
+  useClones: false,
+});
+
+const MAX_HOLDER_CACHE_AGE_MS = Math.max(CACHE_TTL_SECONDS * 1000, 60 * 1000);
 
 function normalisePath(path) {
   if (!path.startsWith('/')) {
@@ -381,11 +390,53 @@ async function getCompletionsForAsset(assetId) {
   const cacheKey = `completions:${assetId}`;
   const cached = responseCache.get(cacheKey);
   try {
+    const holdersPayload = await getAssetHolders(assetId);
+    const payload = {
+      assetId: holdersPayload.assetId,
+      completions: Array.isArray(holdersPayload.holders) ? holdersPayload.holders.length : 0,
+      updatedAt: holdersPayload.updatedAt,
+      source: holdersPayload.source,
+      meta: holdersPayload.meta,
+    };
+    if (holdersPayload.stale) {
+      payload.stale = true;
+    }
+    responseCache.set(cacheKey, payload);
+    console.info('[Algoland API] Completions computed', {
+      assetId,
+      completions: payload.completions,
+      stale: Boolean(payload.stale),
+      scannedBalances: payload.meta?.scannedBalances,
+      durationMs: payload.meta?.durationMs,
+    });
+    return payload;
+  } catch (error) {
+    if (cached) {
+      console.warn('[Algoland API] Completions falling back to cache', {
+        assetId,
+        message: error.message,
+      });
+      return { ...cached, stale: true };
+    }
+    throw error;
+  }
+}
+
+async function getAssetHolders(assetId) {
+  const cacheKey = `holders:${assetId}`;
+  const cachedWrapper = assetHoldersCache.get(cacheKey);
+  const now = Date.now();
+  if (cachedWrapper && cachedWrapper.payload && typeof cachedWrapper.cachedAt === 'number') {
+    const age = now - cachedWrapper.cachedAt;
+    if (age <= MAX_HOLDER_CACHE_AGE_MS) {
+      return { ...cachedWrapper.payload };
+    }
+  }
+
+  try {
     const start = performance.now();
     const holders = new Set();
-    const {
-      adminAddresses,
-    } = await getAssetMetadata(assetId);
+    const { adminAddresses } = await getAssetMetadata(assetId);
 
     const excludedAddresses = new Set(
       getAllowlistForAsset(assetId)
@@ -428,34 +479,36 @@ async function getCompletionsForAsset(assetId) {
     } while (nextToken);
 
     const durationMs = performance.now() - start;
+    const sortedHolders = Array.from(holders).sort();
     const payload = {
       assetId: Number.parseInt(assetId, 10),
-      completions: holders.size,
+      holders: sortedHolders,
       updatedAt: new Date().toISOString(),
       source: INDEXER_BASE,
       meta: {
         durationMs,
         pageCount,
         scannedBalances: accountCount,
-        uniqueHolders: holders.size,
+        uniqueHolders: sortedHolders.length,
       },
+      stale: false,
     };
-    responseCache.set(cacheKey, payload);
-    console.info('[Algoland API] Completions computed', {
+    assetHoldersCache.set(cacheKey, { payload, cachedAt: now });
+    console.info('[Algoland API] Asset holders enumerated', {
       assetId,
-      completions: holders.size,
+      holders: sortedHolders.length,
       pageCount,
       scannedBalances: accountCount,
       durationMs,
     });
     return payload;
   } catch (error) {
-    if (cached) {
-      console.warn('[Algoland API] Completions falling back to cache', {
+    if (cachedWrapper && cachedWrapper.payload) {
+      console.warn('[Algoland API] Holder enumeration falling back to cache', {
         assetId,
         message: error.message,
       });
-      return { ...cached, stale: true };
+      return { ...cachedWrapper.payload, stale: true };
     }
     throw error;
   }
@@ -494,6 +547,87 @@ app.get('/api/entrants', async (req, res) => {
     };
     if (payload.stale) {
       responseBody.stale = true;
+    }
+    res.json(responseBody);
+  } catch (error) {
+    sendCachedOrError(res, error);
+  }
+});
+
+app.get('/api/prizes', async (req, res) => {
+  res.set('Cache-Control', 'no-store');
+  try {
+    const prizes = await getAllPrizes();
+    res.json({
+      weeks: prizes.map((prize) => ({
+        week: prize.week,
+        status: prize.status,
+        asa: prize.asa,
+        assetId: prize.assetId ?? null,
+        image: prize.image ?? null,
+      })),
+    });
+  } catch (error) {
+    console.error('[Algoland API] Failed to load prize configuration', { message: error.message });
+    res.status(500).json({
+      error: 'prize_config_unavailable',
+      message: 'Prize configuration is currently unavailable. Please retry shortly.',
+    });
+  }
+});
+
+app.get('/api/prizes/:week', async (req, res) => {
+  res.set('Cache-Control', 'no-store');
+  const weekParam = req.params.week;
+  let prize;
+  try {
+    prize = await getPrizeForWeek(weekParam);
+  } catch (error) {
+    console.error('[Algoland API] Failed to read prize configuration', { message: error.message });
+    res.status(500).json({
+      error: 'prize_config_unavailable',
+      message: 'Prize configuration is currently unavailable. Please retry shortly.',
+    });
+    return;
+  }
+
+  if (!prize) {
+    res.status(400).json({ error: 'invalid_week', message: 'Week must be between 1 and 13.' });
+    return;
+  }
+
+  if (!prize.assetId || !prize.image) {
+    res.json({
+      week: prize.week,
+      status: 'coming-soon',
+      asa: prize.asa,
+      assetId: prize.assetId ?? null,
+      image: prize.image ?? null,
+      message: 'Prize details coming soon. Check back soon.',
+    });
+    return;
+  }
+
+  try {
+    const holdersPayload = await getAssetHolders(prize.assetId);
+    const winners = Array.isArray(holdersPayload.holders) ? holdersPayload.holders : [];
+    const responseBody = {
+      week: prize.week,
+      status: 'available',
+      asa: prize.asa,
+      assetId: prize.assetId,
+      image: prize.image,
+      winners,
+      winnersCount: winners.length,
+      updatedAt: holdersPayload.updatedAt,
+      source: holdersPayload.source,
+    };
+    if (holdersPayload.meta) {
+      responseBody.meta = holdersPayload.meta;
+    }
+    if (holdersPayload.stale) {
+      responseBody.stale = true;
+      responseBody.status = 'stale';
     }
     res.json(responseBody);
   } catch (error) {

--- a/backend/prizeStore.js
+++ b/backend/prizeStore.js
@@ -1,0 +1,140 @@
+import { readFile, stat } from 'node:fs/promises';
+
+const PRIZES_FILE = new URL('./prizes', import.meta.url);
+const TOTAL_WEEKS = 13;
+
+let cachedPrizes = null;
+let cachedMtime = 0;
+
+function createDefaultPrize(week) {
+  return {
+    week,
+    asa: 'Coming soon',
+    assetId: null,
+    image: null,
+    status: 'coming-soon',
+  };
+}
+
+function normaliseString(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : '';
+  }
+  return '';
+}
+
+function normalisePrizeEntry(rawEntry) {
+  if (!rawEntry || typeof rawEntry !== 'object') {
+    return null;
+  }
+  const weekNumber = Number.parseInt(rawEntry.week, 10);
+  if (!Number.isFinite(weekNumber) || weekNumber < 1) {
+    return null;
+  }
+  const entry = createDefaultPrize(weekNumber);
+
+  const asaRaw = rawEntry.asa ?? rawEntry.ASA ?? rawEntry.assetId ?? rawEntry.asset ?? rawEntry.id;
+  const asaLabel = normaliseString(asaRaw);
+  if (asaLabel) {
+    entry.asa = asaLabel;
+    if (/^\d+$/.test(asaLabel)) {
+      const parsedAssetId = Number.parseInt(asaLabel, 10);
+      if (Number.isFinite(parsedAssetId) && parsedAssetId > 0) {
+        entry.assetId = parsedAssetId;
+        entry.asa = String(parsedAssetId);
+      }
+    }
+  }
+
+  const imageRaw = rawEntry.image ?? rawEntry.imageName ?? rawEntry.assetImage ?? rawEntry.filename;
+  const imageName = normaliseString(imageRaw);
+  if (imageName) {
+    entry.image = imageName;
+  }
+
+  if (entry.assetId && entry.image) {
+    entry.status = 'available';
+  }
+
+  return entry;
+}
+
+async function loadPrizesInternal() {
+  let fileStat;
+  try {
+    fileStat = await stat(PRIZES_FILE);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      const fallback = Array.from({ length: TOTAL_WEEKS }, (_, index) => createDefaultPrize(index + 1));
+      cachedPrizes = {
+        weeks: fallback,
+        byWeek: new Map(fallback.map((item) => [item.week, item])),
+      };
+      cachedMtime = 0;
+      return cachedPrizes;
+    }
+    throw error;
+  }
+
+  if (cachedPrizes && cachedMtime === fileStat.mtimeMs) {
+    return cachedPrizes;
+  }
+
+  const raw = await readFile(PRIZES_FILE, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error('Prize configuration file is not valid JSON.');
+  }
+
+  const byWeek = new Map();
+  if (Array.isArray(parsed)) {
+    parsed.forEach((item) => {
+      const entry = normalisePrizeEntry(item);
+      if (!entry) {
+        return;
+      }
+      byWeek.set(entry.week, entry);
+    });
+  }
+
+  const weeks = [];
+  for (let week = 1; week <= TOTAL_WEEKS; week += 1) {
+    const entry = byWeek.get(week) || createDefaultPrize(week);
+    if (!byWeek.has(week)) {
+      byWeek.set(week, entry);
+    }
+    weeks.push(entry);
+  }
+
+  cachedPrizes = { weeks, byWeek };
+  cachedMtime = fileStat.mtimeMs;
+  return cachedPrizes;
+}
+
+export async function getAllPrizes() {
+  const data = await loadPrizesInternal();
+  return data.weeks.map((item) => ({ ...item }));
+}
+
+export async function getPrizeForWeek(week) {
+  const targetWeek = Number.parseInt(week, 10);
+  if (!Number.isFinite(targetWeek) || targetWeek < 1 || targetWeek > TOTAL_WEEKS) {
+    return null;
+  }
+  const data = await loadPrizesInternal();
+  const entry = data.byWeek.get(targetWeek);
+  if (!entry) {
+    return createDefaultPrize(targetWeek);
+  }
+  return { ...entry };
+}
+
+export function getTotalWeeks() {
+  return TOTAL_WEEKS;
+}

--- a/backend/prizes
+++ b/backend/prizes
@@ -1,0 +1,15 @@
+[
+  { "week": 1, "asa": "3215542832", "image": "Prize1.png" },
+  { "week": 2, "asa": "Coming soon", "image": null },
+  { "week": 3, "asa": "Coming soon", "image": null },
+  { "week": 4, "asa": "Coming soon", "image": null },
+  { "week": 5, "asa": "Coming soon", "image": null },
+  { "week": 6, "asa": "Coming soon", "image": null },
+  { "week": 7, "asa": "Coming soon", "image": null },
+  { "week": 8, "asa": "Coming soon", "image": null },
+  { "week": 9, "asa": "Coming soon", "image": null },
+  { "week": 10, "asa": "Coming soon", "image": null },
+  { "week": 11, "asa": "Coming soon", "image": null },
+  { "week": 12, "asa": "Coming soon", "image": null },
+  { "week": 13, "asa": "Coming soon", "image": null }
+]

--- a/styles/main.css
+++ b/styles/main.css
@@ -1644,6 +1644,165 @@ body.about-page .hero-logo {
   background: rgba(0, 0, 0, 0.4);
 }
 
+body.prize-modal-open {
+  overflow: hidden;
+}
+
+.prize-modal[hidden] {
+  display: none !important;
+}
+
+.prize-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(16px, 4vw, 32px);
+  background: rgba(5, 9, 20, 0.76);
+  backdrop-filter: blur(8px);
+  z-index: 1200;
+  overflow-y: auto;
+}
+
+.prize-modal__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 9, 20, 0.85);
+  z-index: 0;
+}
+
+.prize-modal__dialog {
+  position: relative;
+  width: min(560px, 100%);
+  background: rgba(14, 14, 14, 0.96);
+  border: 1px solid rgba(38, 211, 197, 0.4);
+  border-radius: 22px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.5);
+  padding: clamp(24px, 4vw, 36px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 20px);
+  z-index: 1;
+}
+
+.prize-modal__close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1.5rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.prize-modal__close:hover,
+.prize-modal__close:focus-visible {
+  background: rgba(255, 255, 255, 0.2);
+  color: #ffffff;
+  outline: none;
+}
+
+.prize-modal__content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 3vw, 24px);
+  text-align: center;
+}
+
+.prize-modal__content h2 {
+  margin: 0;
+  font-size: clamp(1.4rem, 4vw, 1.8rem);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.prize-modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 3vw, 18px);
+}
+
+.prize-modal__image {
+  width: min(260px, 65vw);
+  height: auto;
+  align-self: center;
+  border-radius: 16px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+.prize-modal__message {
+  margin: 0;
+  font-size: 1.05rem;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.prize-modal__asa {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.prize-modal__subheading {
+  margin: 12px 0 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(38, 211, 197, 0.9);
+}
+
+.prize-modal__winners {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.prize-modal__winners li {
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(24, 24, 24, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.85);
+  word-break: break-all;
+}
+
+.prize-modal__empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.prize-modal__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+@media (max-width: 480px) {
+  .prize-modal__dialog {
+    padding: 24px;
+  }
+
+  .prize-modal__close {
+    width: 32px;
+    height: 32px;
+    font-size: 1.25rem;
+  }
+}
+
 @media (min-width: 768px) {
   .site-footer {
     text-align: right;


### PR DESCRIPTION
## Summary
- update the week 1 prize ASA everywhere it appears so the frontend, backend config, and prizes dataset stay in sync
- dynamically create the prize modal in JavaScript so the page structure stays untouched while week cards wire up click handlers only
- keep the backend prize endpoints intact while continuing to enumerate ASA holders from the indexer

## Testing
- curl http://127.0.0.1:3000/api/prizes
- curl -s -w '\n%{http_code}\n' http://127.0.0.1:3000/api/prizes/2
- curl -s -w '\n%{http_code}\n' http://127.0.0.1:3000/api/prizes/1 *(fails: upstream indexer blocked in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f960adec8322a2367ac35169246c