### PR TITLE
Fix week 1 Algoland asset identifiers

### DIFF
--- a/algoland.html
+++ b/algoland.html
@@ -133,7 +133,7 @@
             <span class="week-card__count-number" data-week-completions>—</span>
             <span class="week-card__count-label">badges claimed</span>
           </p>
-          <p class="week-card__badge">Badge ASA <span data-week-badge>3215542836</span></p>
+          <p class="week-card__badge">Badge ASA <span data-week-badge>3215542831</span></p>
           <p class="week-card__opens" data-week-open-text>Opened 22 September 2025</p>
         </article>
         <article class="week-card is-open has-rollover" data-week-card data-week="2" data-opens-on="2025-09-29">
@@ -306,7 +306,7 @@
           <tbody>
             <tr data-week="1">
               <th scope="row">Week 1</th>
-              <td data-col="badge" class="is-hidden-column">3215542836</td>
+              <td data-col="badge" class="is-hidden-column">3215542831</td>
               <td data-col="distributor" data-distributor-index="0" class="is-hidden-column"></td>
               <td data-col="entrants" title="Wallets opted in to application 3215540125." class="is-hidden-column">—</td>
               <td data-col="completed" title="Wallets that received the week’s badge from the official distributor.">—</td>

--- a/assets/algoland.js
+++ b/assets/algoland.js
@@ -13,7 +13,7 @@
   const prizeModal = createPrizeModal();
 
   const weeksConfig = [
-    { week: 1, assetId: '3215542832', distributors: [DEFAULT_DISTRIBUTOR], opensOn: '2025-09-22' },
+    { week: 1, assetId: '3215542831', distributors: [DEFAULT_DISTRIBUTOR], opensOn: '2025-09-22' },
     { week: 2, assetId: '3215542840', distributors: [DEFAULT_DISTRIBUTOR], opensOn: '2025-09-29' },
     { week: 3, assetId: '3215542836', distributors: [DEFAULT_DISTRIBUTOR], opensOn: '2025-10-06' },
     { week: 4, assetId: '', distributors: [DEFAULT_DISTRIBUTOR], opensOn: '2025-10-13' },

--- a/backend/README.md
+++ b/backend/README.md
@@ -33,6 +33,6 @@ The service listens on `http://localhost:3000` by default. Configure the followi
 4. After deployment succeeds, verify:
    - `/api/ping` responds with service metadata.
    - `/api/entrants` returns the entrants count and timestamp.
-   - `/api/completions?asset=3215542832` returns the completions count for week 1.
+  - `/api/completions?asset=3215542831` returns the completions count for week 1.
 
 Remember to update the static site configuration so `/algoland` fetches data from the deployed Render URL.

--- a/backend/config.js
+++ b/backend/config.js
@@ -3,7 +3,7 @@ const PARSED_APP_ID = Number.parseInt(RAW_APP_ID, 10);
 export const APP_ID = Number.isFinite(PARSED_APP_ID) ? PARSED_APP_ID : 3215540125;
 
 export const WEEK_CONFIG = [
-  { week: 1, assetId: 3215542836 },
+  { week: 1, assetId: 3215542831 },
   { week: 2, assetId: 3215542840 },
   { week: 3, assetId: null },
   { week: 4, assetId: null },
@@ -23,6 +23,7 @@ const DEFAULT_DISTRIBUTOR = 'HHADCZKQV24QDCBER5GTOH7BOLF4ZQ6WICNHAA3GZUECIMJXIIM
 export const DISTRIBUTOR_ALLOWLIST = {
   default: [DEFAULT_DISTRIBUTOR],
   byAsset: {
+    3215542831: [DEFAULT_DISTRIBUTOR],
     3215542836: [DEFAULT_DISTRIBUTOR],
     3215542840: [DEFAULT_DISTRIBUTOR],
   },

--- a/backend/prizes
+++ b/backend/prizes
@@ -1,5 +1,5 @@
 [
-  { "week": 1, "asa": "3215542832", "image": "Prize1.png" },
+  { "week": 1, "asa": "3215542836", "image": "Prize1.png" },
   { "week": 2, "asa": "Coming soon", "image": null },
   { "week": 3, "asa": "Coming soon", "image": null },
   { "week": 4, "asa": "Coming soon", "image": null },


### PR DESCRIPTION
## Summary
- update the Week 1 badge configuration to use ASA 3215542831 in the frontend and backend
- record the Week 1 prize ASA as 3215542836
- refresh backend documentation to reference the new completion endpoint asset

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e40ca8138c8322879c1da45db6cf6a