### PR TITLE
Add honeypot protection to contact form

### DIFF
--- a/assets/site.js
+++ b/assets/site.js
@@ -537,6 +537,16 @@ if (window.top !== window.self) {
       return typeof value === 'string' ? value.trim() : '';
     };
 
+    const honeypotValue = getValue('_honey');
+    if (honeypotValue) {
+      form.reset();
+      if (subjectSelect) {
+        subjectSelect.value = 'General enquiry';
+      }
+      setSubmittingState(false);
+      return;
+    }
+
     const message = getValue('message');
     if (messageInput && message.length < 10) {
       messageInput.setCustomValidity('Message must be at least 10 characters long.');

--- a/contact.html
+++ b/contact.html
@@ -148,7 +148,10 @@
           <input type="hidden" name="_template" value="table">
           <input type="hidden" name="_captcha" value="false">
           <input type="hidden" name="_next" value="https://www.emnetcm.com/contact?submitted=true">
-          <input type="hidden" name="_honey" tabindex="-1" autocomplete="off" class="contact-form__honeypot" aria-hidden="true">
+          <div class="contact-form__honeypot" aria-hidden="true">
+            <label for="contact-company">Company</label>
+            <input id="contact-company" type="text" name="_honey" tabindex="-1" autocomplete="off">
+          </div>
           <p class="contact-form__privacy">We only use your details to respond to your enquiry. Read our <a href="privacy.html">Privacy Policy</a>.</p>
           <p class="contact-form__error js-contact-error" hidden role="alert" aria-live="assertive">We couldn&rsquo;t send your message just now. Please try again or email <a href="mailto:emnet@emnetcm.com">emnet@emnetcm.com</a>.</p>
           <p class="contact-form__confirmation js-contact-confirmation" hidden role="status" aria-live="polite">Thank you, we&rsquo;ll be in touch shortly.</p>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1036,6 +1036,19 @@ body.about-page .hero-logo {
   overflow: hidden;
 }
 
+.contact-form__honeypot input,
+.contact-form__honeypot label {
+  display: block;
+  width: 1px;
+  height: 1px;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 .individual-services ul {
   list-style: none;
   margin: 24px 0 0;


### PR DESCRIPTION
## Summary
- add a visually hidden honeypot field to the contact form markup
- style the honeypot field so it does not affect the page layout while remaining detectable to bots
- short-circuit form submission when the honeypot is filled to ignore bot submissions

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e42fb8e3d88322b9cda75b016d524a