### PR TITLE
Switch Algoland lookup to Lands Inspector API

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,12 +1,13 @@
 # Algoland backend API
 
-This directory contains a small Express service that proxies Algorand Indexer queries on behalf of the public Algoland dashboard. It exposes cached endpoints that the static site can call without shipping any credentials or provider URLs to browsers.
+This directory contains a small Express service that proxies Algorand Indexer queries and the Lands Inspector API on behalf of the public Algoland dashboard. It exposes cached endpoints that the static site can call without shipping any credentials or provider URLs to browsers.
 
 ## Endpoints
 
 - `GET /api/ping` — health check that reports configuration basics.
 - `GET /api/entrants` — total entrant wallets with local state for application `3215540125`.
 - `GET /api/completions?asset=<assetId>` — unique receivers of positive badge transfers for a given ASA.
+- `GET /api/algoland-stats?address=<address>` — fetches decoded campaign progress for a wallet by forwarding the request to the Lands Inspector API.
 
 All responses are cached in-memory for five minutes by default. When the upstream Indexer is unavailable the service falls back to the last cached payload and marks it as `stale: true`.
 
@@ -22,6 +23,7 @@ The service listens on `http://localhost:3000` by default. Configure the followi
 
 - `ALLOWED_ORIGINS` — comma-separated list of origins permitted to access the API. Example: `https://emnetcm.com,https://www.emnetcm.com`.
 - `INDEXER_BASE` — Algorand Indexer base URL. Defaults to `https://mainnet-idx.algonode.cloud`.
+- `LANDS_INSPECTOR_BASE` — Lands Inspector base URL. Defaults to `https://landsinspector.pages.dev`.
 - `CACHE_TTL_SECONDS` — overrides the default 300 second cache TTL.
 - `INDEXER_MAX_RETRIES` and `INDEXER_RETRY_BASE_MS` — adjust retry behaviour when the Indexer returns 429 or 5xx responses.
 

--- a/docs/algoland-profile-lookup.md
+++ b/docs/algoland-profile-lookup.md
@@ -8,8 +8,8 @@ This release introduces an on-page Algorand address and Algoland ID lookup workf
 - Provides accessible status messaging, focus management, and loading indicators to keep the experience usable with keyboards and assistive technologies.
 
 ## Back-end
-- Exposes a `/api/algoland-stats` endpoint that accepts addresses or IDs, normalises indexer responses, and caches decoded profiles to avoid redundant blockchain calls.
-- Includes resilient retry logic with exponential back-off for indexer requests and structured error responses for empty, invalid, or missing profiles.
+- Exposes a `/api/algoland-stats` endpoint that accepts addresses or IDs, forwards wallet lookups to the Lands Inspector API, and caches the decoded response so repeat queries avoid redundant upstream calls.
+- Treats missing Lands Inspector records as empty-but-successful responses so the UI can show a friendly “no activity yet” message instead of an error.
 - Shares caching utilities with existing entrants/completions endpoints so the new lookup can leverage warm data where available.
 
 ## Screenshot


### PR DESCRIPTION
## Summary
- swap the backend Algoland profile lookup to the Lands Inspector API, caching parsed responses and returning an empty profile when no data is found
- refresh the Algoland search modal to surface friendly "no activity" messaging, available challenge lists, and prize details from the new payload
- document the Lands Inspector integration and configuration updates

## Testing
- npm run lint *(fails: run-p not found because npm install is blocked by 403 errors from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d947fc2883229ba9602aae9d7f1f