### PR TITLE
Fix Lands Inspector point scaling

### DIFF
--- a/backend/__tests__/inspector.test.js
+++ b/backend/__tests__/inspector.test.js
@@ -17,8 +17,13 @@ test('buildInspectorProfile resolves nested Lands Inspector values', async () =>
     },
     stats: {
       overview: {
-        pointsBalance: '78000',
-        redeemedPoints: '1200',
+        pointsBalance: {
+          value: '78000',
+          decimals: 1,
+        },
+        redeemedPoints: {
+          value: '1200',
+        },
         weeklyDraws: {
           eligible: true,
           entries: 5,
@@ -40,14 +45,14 @@ test('buildInspectorProfile resolves nested Lands Inspector values', async () =>
   };
 
   const resolvedPoints = extractInspectorValue(payload, ['points', 'pointsBalance']);
-  assert.equal(resolvedPoints, '78000');
+  assert.equal(resolvedPoints.value, '78000');
 
   const profile = buildInspectorProfile(
     'EMNETCRVN2B4LYV4BDQ5JFYBJVAK663G2AOEENUV2WZK5U6FS3LNEIWTCU',
     payload,
   );
 
-  assert.equal(profile.points, 78000);
+  assert.equal(profile.points, 7800);
   assert.equal(profile.pointsRaw, 78000);
   assert.equal(profile.redeemedPoints, 1200);
   assert.equal(profile.relativeId, 12);


### PR DESCRIPTION
## Summary
- detect scaling metadata in Lands Inspector payloads so point totals are normalised correctly
- surface the unscaled raw point value when building inspector profiles for easier diagnostics
- update the inspector profile test fixture to cover decimal-aware payloads

## Testing
- node --test __tests__/inspector.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e64bfa78b48322986aa15b7d2e750e