### PR TITLE
Use algosdk for backend address validation

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,3 +1,4 @@
+import algosdk from 'algosdk';
 import cors from 'cors';
 import express from 'express';
 import rateLimit from 'express-rate-limit';
@@ -18,8 +19,6 @@ const LANDS_INSPECTOR_BASE = (process.env.LANDS_INSPECTOR_BASE || 'https://lands
 const CACHE_TTL_SECONDS = Number.parseInt(process.env.CACHE_TTL_SECONDS || '', 10) || 300;
 const MAX_RETRIES = Number.parseInt(process.env.INDEXER_MAX_RETRIES || '', 10) || 5;
 const RETRY_BASE_DELAY_MS = Number.parseInt(process.env.INDEXER_RETRY_BASE_MS || '', 10) || 500;
-
-const ALGOLAND_ADDRESS_PATTERN = /^[A-Z2-7]{58}$/;
 
 const RELATIVE_ID_KEYS = [
   'relativeid',
@@ -391,11 +390,18 @@ function isAlgorandAddress(value) {
   if (typeof value !== 'string') {
     return false;
   }
-  const trimmed = value.trim().toUpperCase();
+  const trimmed = value.trim();
   if (trimmed.length !== 58) {
     return false;
   }
-  return ALGOLAND_ADDRESS_PATTERN.test(trimmed);
+  try {
+    return algosdk.isValidAddress(trimmed);
+  } catch (error) {
+    console.warn('[Algoland API] Address validation failed', {
+      message: error.message,
+    });
+    return false;
+  }
 }
 
 function parseStateValue(stateValue) {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "dev": "node --watch index.js"
   },
   "dependencies": {
+    "algosdk": "^3.5.2",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "express-rate-limit": "^7.3.0",


### PR DESCRIPTION
## Summary
- add the official Algorand JavaScript SDK to the backend and reuse its `isValidAddress` helper instead of a regex
- log SDK validation failures so operational alerts can capture malformed inputs

## Testing
- node -e "process.env.NODE_ENV='test'; import('./backend/index.js').then(()=>console.log('loaded'));"

## References
- Algorand JavaScript SDK v3.5.2 (released 2025-09-11): https://github.com/algorand/js-algorand-sdk/releases/tag/v3.5.2

------
https://chatgpt.com/codex/tasks/task_e_68e65959ba68832291406f7cdad6e23f